### PR TITLE
Accept config.paths.nodeModules (support Lerna repos)

### DIFF
--- a/src/static/getConfig.js
+++ b/src/static/getConfig.js
@@ -163,6 +163,7 @@ export const buildConfigation = (config = {}) => {
     dist: 'dist',
     devDist: 'tmp/dev-server',
     public: 'public',
+    nodeModules: 'node_modules',
     ...(config.paths || {}),
   }
 
@@ -181,7 +182,8 @@ export const buildConfigation = (config = {}) => {
     SRC: resolvePath(config.paths.src),
     DIST: distPath,
     PUBLIC: resolvePath(config.paths.public),
-    NODE_MODULES: resolvePath('node_modules'),
+    NODE_MODULES: resolvePath(config.paths.nodeModules),
+    EXCLUDE_MODULES: config.paths.excludeResolvedModules || resolvePath(config.paths.nodeModules),
     PACKAGE: resolvePath('package.json'),
     HTML_TEMPLATE: path.join(distPath, 'index.html'),
     STATIC_DATA: path.join(distPath, 'staticData'),

--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -1,7 +1,7 @@
 export default function ({ config, stage }) {
   return {
     test: /\.(js|jsx)$/,
-    exclude: config.paths.NODE_MODULES,
+    exclude: config.paths.EXCLUDE_MODULES,
     use: [
       {
         loader: 'babel-loader',


### PR DESCRIPTION
This PR adds the ability to customize your node_modules path via `config.paths.nodeModules`, as well as the ability to exclude multiple directories from webpack via `config.paths.excludeResolvedModules` (must be pre-resolved, not relative, as it can be an array).

This is necessary for some [Lerna](https://github.com/lerna/lerna) projects which may have a root node_modules directory that contains hoisted dependencies.

**Fully backward-compatible**; no breaking changes. Example `static.config` for a Lerna project:

```js
paths: {
  nodeModules: '../../node_modules',
  excludeResolvedModules: [
    path.resolve(__dirname, '../../node_modules'),
    path.resolve(__dirname, 'node_modules'),
  ],
},
```

---

If this is a change you'd consider accepting, please advise me on what sort of tests you expect (currently I don't think there are any related tests or specific documentation, but feel free to point me in the right direction if there are).