### PR TITLE
Add docs.stoplight.io to sites built

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ React-Static is a fast, lightweight, and powerful framework for building static-
 * [Luke Haas - Personal Website](https://lukehaas.me)
 * [KleineKoning.nl - Webshop](https://kleinekoning.nl)
 * [Savieo - Save Web Videos](https://savieo.com)
+* [Stoplight.io - Documentation & API Reference](https://docs.stoplight.io)
 
 ## Quick Start
 


### PR DESCRIPTION
## Description

[Stoplight](https://next.stoplight.io) uses React Static internally to build static documentation for our customers.  We also use it for our own technical documentation and API reference.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7423098/45821181-312a7e80-bcae-11e8-869b-96900c6f0eef.png)