### PR TITLE
Upgrade TypeScript definition, (re)add renderProp for Routes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,5 @@ res
 plugins
 platforms
 tmp
+
+*.d.ts

--- a/packages/react-static/src/browser/components/Routes.js
+++ b/packages/react-static/src/browser/components/Routes.js
@@ -9,11 +9,43 @@ import {
   prefetch,
   plugins,
   onReloadTemplates,
-} from ".."
+} from '..'
 import { useStaticInfo } from '../hooks/useStaticInfo'
 import { routePathContext, useRoutePath } from '../hooks/useRoutePath'
 
-const RoutesInner = ({ routePath }) => {
+/**
+ *
+ * @param {string} path
+ * @returns {React.ComponentType<{}> | false}
+ */
+function getTemplateForPath(path) {
+  let is404 = path === '404'
+  let Comp = templatesByPath[path] || false
+
+  if (!Comp && templateErrorByPath[path]) {
+    is404 = true
+    Comp = templatesByPath['404'] || false
+  }
+
+  return { is404, Comp }
+}
+
+/**
+ *
+ *
+ * @param {string} path
+ * @returns {React.ReactNode | false}
+ */
+function getComponentForPath(path) {
+  const { Comp, is404 } = getTemplateForPath(path)
+  if (is404 || !Comp) {
+    return false
+  }
+
+  return React.createElement(Comp, { is404 })
+}
+
+const RoutesInner = ({ routePath, render: renderFn }) => {
   // Let the user specify a manual routePath.
   // This is useful for animations where multiple routes
   // might be rendered simultaneously
@@ -63,16 +95,7 @@ const RoutesInner = ({ routePath }) => {
   routePath = useRoutePath(routePath)
 
   // Try and get the template
-  let Comp = templatesByPath[routePath]
-
-  // Detect a 404
-  let is404 = routePath === '404'
-
-  // Detect a failed template
-  if (templateErrorByPath[routePath]) {
-    is404 = true
-    Comp = templatesByPath['404']
-  }
+  const { Comp, is404 } = getTemplateForPath(routePath)
 
   if (!Comp) {
     if (is404) {
@@ -89,23 +112,24 @@ const RoutesInner = ({ routePath }) => {
 
   return (
     <routePathContext.Provider value={routePath}>
-      <Comp is404={is404} />
+      {renderFn ? renderFn({ routePath, getComponentForPath }) : (<Comp is404={is404} />)}
     </routePathContext.Provider>
   )
 }
 
-const Routes = ({ routePath }) => {
+const Routes = ({ ...originalProps }) => {
   // Once a routePath goes into the Routes component,
   // useRoutePath must ALWAYS return the routePath used
   // in its parent, so we pass it down as context
-
+  console.log('routes plugin:', plugins.Routes)
   // Get the Routes hook
   const CompWrapper = useMemo(
     () => plugins.Routes(props => <RoutesInner {...props} />),
     [plugins]
   )
 
-  return <CompWrapper routePath={routePath} />
+  // Pass all props so that plugins can use it
+  return <CompWrapper {...originalProps} />
 }
 
 export default Routes

--- a/packages/react-static/src/browser/components/Routes.js
+++ b/packages/react-static/src/browser/components/Routes.js
@@ -112,7 +112,11 @@ const RoutesInner = ({ routePath, render: renderFn }) => {
 
   return (
     <routePathContext.Provider value={routePath}>
-      {renderFn ? renderFn({ routePath, getComponentForPath }) : (<Comp is404={is404} />)}
+      {renderFn ? (
+        renderFn({ routePath, getComponentForPath })
+      ) : (
+        <Comp is404={is404} />
+      )}
     </routePathContext.Provider>
   )
 }
@@ -121,7 +125,7 @@ const Routes = ({ ...originalProps }) => {
   // Once a routePath goes into the Routes component,
   // useRoutePath must ALWAYS return the routePath used
   // in its parent, so we pass it down as context
-  console.log('routes plugin:', plugins.Routes)
+
   // Get the Routes hook
   const CompWrapper = useMemo(
     () => plugins.Routes(props => <RoutesInner {...props} />),

--- a/packages/react-static/src/browser/index.d.ts
+++ b/packages/react-static/src/browser/index.d.ts
@@ -1,0 +1,111 @@
+// For convenience, only declare the exports here that are exported from
+// the react-static main index.js.
+
+/**
+ * addPrefetchExcludes allows you to register dynamic route exclusions at
+ * runtime, so as to not produce 404 errors when attempting to preload static
+ * data / templates that link to these routes.
+ *
+ * @param {...ReadonlyArray<string>} excludes
+ */
+export function addPrefetchExcludes(...excludes: ReadonlyArray<string | RegExp>): void;
+
+/**
+ * @private
+ */
+export function getRouteInfo(path: string, options?: { priority: number }): Promise<unknown>;
+
+
+/**
+ * @private
+ */
+export function isPrefetchableRoute(path: string): boolean;
+
+/**
+ * @private
+ */
+export function onReloadClientData(fn: () => void): void;
+
+/**
+ * @private
+ */
+export function onReloadTemplates(fn: () => void): void;
+
+/**
+ * @private
+ */
+export const pluginHooks: unknown[];
+
+/**
+ * @private
+ */
+export const plugins: {
+  Root: (Comp: unknown) => unknown,
+  Routes: (Comp: unknown) => unknown
+}
+
+/**
+ * Prefetches the route given as `path` and resolves its `routeData`
+ *
+ * @see usePrefetch
+ *
+ * @template T the route data
+ * @param {string} path the path to prefetch
+ * @returns {Promise<T>} the promise that resolves the route data
+ */
+export function prefetch<T extends unknown = any>(path: string, options?: { type?: 'data' | 'template', priority?: number }): Promise<undefined | T>
+
+/**
+ * @private
+ */
+export function prefetchData<T extends unknown = any>(path: string, options?: { priority?: number }): undefined | T;
+
+/**
+ * @private
+ */
+export function prefetchTemplate<T extends React.ComponentType = any>(path: string, options?: { priority?: number }): undefined | T;
+
+/**
+ * @private
+ */
+export function registerPlugins(newPlugins: unknown[]): void;
+
+/**
+ * @private
+ */
+export function registerTemplateForPath(path: string, template: string): void;
+
+/**
+ * @private
+ */
+export function registerTemplates(templates: { [template: string]: React.ComponentType }, notFoundKey: string): Promise<void>;
+
+/**
+ * @private
+ */
+export const routeErrorByPath: { [path: string]: true }
+
+/**
+ * @private
+ */
+export const routeInfoByPath: { [path: string]: unknown }
+
+/**
+ * @private
+ */
+export const sharedDataByHash: { [hash: string]: unknown }
+
+/**
+ * @private
+ */
+export const templateErrorByPath: { [template: string]: true }
+
+/**
+ * @private
+ */
+export const templates: { [template: string]: React.ComponentType }
+
+/**
+ * @private
+ */
+export const templatesByPath: { [path: string]: React.ComponentType }

--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -11,7 +11,7 @@ import { RenderFn } from 'create-react-context';
 
 export { Helmet as Head } from 'react-helmet'
 
-interface StaticInfo<T extends unknown> {
+interface StaticInfo<T extends object> {
   path: string
   siteData: T
 }
@@ -20,11 +20,11 @@ interface RoutesRenderProp {
   getComponentForPath(pathname: string): React.ReactNode | false
 }
 
-interface RouteDataProps<T extends unknown> {
+interface RouteDataProps<T extends object> {
   children: (routeData: T) => React.ReactNode
 }
 
-interface SiteDataProps<T extends unknown> {
+interface SiteDataProps<T extends object> {
   children: (siteData: T) => React.ReactNode
 }
 
@@ -65,7 +65,7 @@ interface SiteDataProps<T extends unknown> {
  *
  * @returns {T} the route data
  */
-export function useRouteData<T extends unknown = any>(): T;
+export function useRouteData<T extends object = any>(): T;
 
 /**
  * Hook to get the Site Data
@@ -80,7 +80,7 @@ export function useRouteData<T extends unknown = any>(): T;
  * @template T the type of the site data
  * @returns {T} the side data
  */
-export function useSiteData<T extends unknown = any>(): T;
+export function useSiteData<T extends object = any>(): T;
 
 /**
  * Hook to prefetch a path as soon as the linked ref becomes visible.
@@ -110,7 +110,7 @@ export function useSiteData<T extends unknown = any>(): T;
  *   }
  *
  */
-export function usePrefetch<T extends unknown>(
+export function usePrefetch<T extends object = any>(
   path: string,
   ref?: React.MutableRefObject<T>
 ): React.MutableRefObject<T>;
@@ -139,7 +139,7 @@ export function useBasepath(): string;
  * @template T the siteData
  * @returns {(StaticInfo<T> | undefined)} the static info, if any
  */
-export function useStaticInfo<T = unknown>(): StaticInfo<T> | undefined;
+export function useStaticInfo<T extends object = any>(): StaticInfo<T> | undefined;
 
 /**
  * Hook to **clean** a route path. Returns the context value if inside a context
@@ -184,7 +184,7 @@ export const routePathContext: React.Context<string>;
  * @param {React.ComponentType<P>} Comp the component to wrap
  * @returns {(React.ComponentClass<P & { routeData: T }, S>)} tbe wrapped component
  */
-export function withRouteData<T extends unknown = any, P extends object = {}, S extends object = {}>(
+export function withRouteData<T extends object = any, P extends object = {}, S extends object = {}>(
   Comp: React.ComponentType<P>
 ):  React.ComponentClass<P & { routeData: T }, S>;
 
@@ -198,7 +198,7 @@ export function withRouteData<T extends unknown = any, P extends object = {}, S 
  * @param {{ children: (routeData: T) => React.ReactNode }} props
  * @returns {React.ReactNode}
  */
-export function RouteData<T extends unknown = any>(
+export function RouteData<T extends object = any>(
   props: RouteDataProps<T>
 ): React.ReactNode
 
@@ -214,7 +214,7 @@ export function RouteData<T extends unknown = any>(
  * @param {React.ComponentType<P>} Comp the component to wrap
  * @returns {(React.ComponentClass<P & { siteData: T }, S>)} tbe wrapped component
  */
-export function witeSiteData<T extends unknown = any, P extends object = {}, S extends object = {}>(
+export function witeSiteData<T extends object = any, P extends object = {}, S extends object = {}>(
   Comp: React.ComponentType<P>
 ):  React.ComponentClass<P & { routeData: T }, S>;
 
@@ -228,7 +228,7 @@ export function witeSiteData<T extends unknown = any, P extends object = {}, S e
  * @param {{ children: (siteData: T) => React.ReactNode }} props
  * @returns {React.ReactNode}
  */
-export function SiteData<T extends unknown = any>(
+export function SiteData<T extends object = any>(
   props: SiteDataProps<T>
 ): React.ReactNode
 
@@ -489,12 +489,14 @@ export interface ReactStaticConfig {
    * @param {RouteFlags} flags
    * @returns {Promise<T>} the promise that resolves the site data
    */
-  getSiteData?<T extends unknown = any>(flags: RouteFlags): Promise<T>
+  getSiteData?(flags: RouteFlags): Promise<object> | object
 
   plugins?: Array<PluginConfiguration>
+
+  entry?: string
 }
 
-export type PluginConfiguration = string | [string, object]
+export type PluginConfiguration = string | [string, object?]
 
 export interface RouteFlags {
   stage: 'dev' | 'prod'
@@ -544,9 +546,9 @@ export interface Route {
    * @template T type of the route data
    * @param {Route} resolvedRoute This is the resolved route this function is handling.
    * @param {RouteFlags} flags An object of flags and meta information about the build
-   * @returns {T} the route data
+   * @returns {T | Promise<T>} the route data
    */
-  getData?<T extends unknown = any>(resolvedRoute: Route, flags: RouteFlags): Promise<T>
+  getData?(resolvedRoute: Route, flags: RouteFlags): Promise<object> | object
 
   replace?: boolean
 }
@@ -573,9 +575,9 @@ export interface PathsConfig {
   nodeModules?: string
 }
 
-export type DocumentComponent<T extends unknown = any> = React.ComponentType<DocumentProps<T>>
+export type DocumentComponent<T extends object = any> = React.ComponentType<DocumentProps<T>>
 
-export interface DocumentProps<T extends unknown = any> {
+export interface DocumentProps<T extends object = any> {
   Html: JSX.IntrinsicElements['html']
   Head: JSX.IntrinsicElements['head']
   Body: JSX.IntrinsicElements['body']

--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -1,94 +1,627 @@
-// Type definitions for react-static 7.0.0
+// Type definitions for react-static 7.0.10
 // Project: https://github.com/nozzle/react-static
-// Definitions for 4.0.1 by: D1no <https://github.com/D1no>
-// Updated to 5.1.7 by: Balvajs <https://github.com/Balvajs>
-// TypeScript Version: 3.4
+// Definitions by: Various Contributors https://github.com/nozzle/react-static/blame/master/packages/react-static/src/index.d.ts
+//
 // VERY lightly maintained, we need all the help we can get
 
-// / <reference types="react" />
+import * as React from 'react';
 
-declare module 'react-static' {
-  import * as React from 'react'
-  import { ComponentType, ReactNodeArray } from 'react'
-  import { Configuration as WebpackDevServerConfig } from 'webpack-dev-server'
+import { Configuration as WebpackDevServerConfig } from 'webpack-dev-server';
+import { RenderFn } from 'create-react-context';
 
-  type AnyReactComponent = ComponentType<Record<string, any>>
+export { Helmet as Head } from 'react-helmet'
 
-  // Passing on helmet typings as "Head"
-  export { Helmet as Head } from 'react-helmet'
+interface StaticInfo<T extends unknown> {
+  path: string
+  siteData: T
+}
 
-  export class Routes extends React.Component<{ path?: String, default?: boolean }> {}
-  export class Root extends React.Component {}
-  export function useRouteData<T = any>(): T
-  export function useSiteData<T = any>(): T
-  export function withRouteData(comp: any): any
-  export function withSiteData(comp: any): any
-  export function prefetch(path: any): Promise<any>
-  export function addPrefetchExcludes(arg: String[]): void
-  export const Prefetch: React.Component
+interface RoutesRenderProp {
+  getComponentForPath(pathname: string): React.ReactNode | false
+}
+
+interface RouteDataProps<T extends unknown> {
+  children: (routeData: T) => React.ReactNode
+}
+
+interface SiteDataProps<T extends unknown> {
+  children: (siteData: T) => React.ReactNode
+}
+
+/**
+ * Hook to get the Route Data for the current route
+ *
+ * Via `React.Suspense`, the `useRouteData` hook asynchronously provides the
+ * results of a routes's `getData` as defined in your `static.config.js`
+ *
+ * @see Route
+ * @see Routes
+ * @see routePathContext
+ *
+ * This will match the `getData()` result from `Route` and
+ * only works if it is called in a child of `routePathContext.Provider`, which
+ * is always the case in a child of the `Routes` component:
+ * - any template/container (the `template` key in `Route`)
+ * - any page via the react-static-plugin-source-filesystem
+ * - if you manually wrap a component with `<routePathContext.Provider>`
+ *
+ * Alternatives include the `RouteData` component and the `withRouteData` HOC.
+ *
+ * @example Getting the route data inside a container (`template`)
+ *
+ *   function PostContainer(): JSX.Element {
+ *     const postData = useRouteData<RouteData>()
+ *     // => { the post data }
+ *   }
+ *
+ * @example Getting the route data _oustide_ the container / page / `Routes`
+ *
+ *   function Outside(): JSX.Element {
+ *     const currentPath = getRoutePath(location.pathName)
+ *     return <routePathContext.Provider value={currentPath}>
+ *      {childThatCallsUseRouteData}
+ *     </routePathContext.Provider>
+ *   }
+ *
+ * @returns {T} the route data
+ */
+export function useRouteData<T extends unknown = any>(): T;
+
+/**
+ * Hook to get the Site Data
+ *
+ * Via `React.Suspense`, the `useSiteData` hook asynchronously provides the
+ * results of the `getSiteData` function as defined in your `static.config.js`.
+ *
+ * @see ReactStaticConfig
+ *
+ * Alternatives include the `SiteData` component and the `withSiteData` HOC.
+ *
+ * @template T the type of the site data
+ * @returns {T} the side data
+ */
+export function useSiteData<T extends unknown = any>(): T;
+
+/**
+ * Hook to prefetch a path as soon as the linked ref becomes visible.
+ *
+ * @param {string} path the path to pre-fetch
+ * @param {React.Ref} [ref]
+ * @returns {React.Ref} returns the prefetch-ref
+ *
+ * The `usePrefetch` hook binds the prefetching of a specific path's assets to
+ * the visibility of an element. When the ref's element becomes visible in the
+ * viewport, the template and data required to render the route for the `path`
+ * will be prefetched.
+ *
+ * @example Using the prefetch hook to prefetch a link
+ *
+ *   import { useRef } from 'react'
+ *   import { usePrefetch } from 'react-static'
+ *   export default () => {
+ *     // Use it to create a ref
+ *     const myRef = usePrefetch('/blog')
+ *
+ *     // or pass your own ref
+ *     const myRef = useRef()
+ *     usePrefetch('./blog', myRef)
+ *
+ *     return (<Link to="/blog" ref={myRef}>Go to blog</Link>)
+ *   }
+ *
+ */
+export function usePrefetch<T extends unknown>(
+  path: string,
+  ref?: React.MutableRefObject<T>
+): React.MutableRefObject<T>;
+
+/**
+ * Hook to get the current Location object (or `undefined` on the first render)
+ *
+ * Makes a component rerender each time the `Location` changes.
+ *
+ * @returns {(Location | undefined)} the current location
+ */
+export function useLocation(): Location | undefined
+
+/**
+ * Hook to get the mounted base path
+ *
+ * @returns {string} empty string when REACT_STATIC_DISABLE_ROUTE_PREFIXING
+ *  is true, REACT_STATIC_BASE_PATH otherwise.
+ */
+export function useBasepath(): string;
+
+/**
+ * Primarily used during the build process and to hydrate the app from static
+ * data. You probably don't need this when writing your app using `react-static`
+ *
+ * @template T the siteData
+ * @returns {(StaticInfo<T> | undefined)} the static info, if any
+ */
+export function useStaticInfo<T = unknown>(): StaticInfo<T> | undefined;
+
+/**
+ * Hook to **clean** a route path. Returns the context value if inside a context
+ * or sanitizes via `getRoutePath` otherwise.
+ *
+ * @param {string} routePath
+ * @returns {string}
+ *
+ * Once a routePath goes into the `Routes` component, `useRoutePath` must ALWAYS
+ * return the `routePath` used in its parent, so the `Routes` component always
+ * passes it down inside a context
+ *
+ * @see getRoutePath
+ * @see routePathContext
+ */
+export function useRoutePath(routePath: string): string;
+
+/**
+ * Context to provide the current route path.
+ *
+ * This is used in the `Routes` component and provides the route path to
+ * `useRoutePath`. If you want to use that hook outside of the `Routes`
+ * component, e.g. a sidebar, you can use this context's Provider to pass the
+ * current route down.
+ *
+ * @see useRouteData
+ * @see useRoutePath
+ *
+ * The `useRouteData` hook has an example how to do this properly.
+ */
+export const routePathContext: React.Context<string>;
+
+/**
+ * HOC that passes the `routeData` as a prop to the wrapped `Component`
+ *
+ * @see useRouteData
+ *
+ * @template T type of the routeData
+ * @template P type of the props of the original `Component`
+ * @template S type of the state of the original `Component`
+ *
+ * @param {React.ComponentType<P>} Comp the component to wrap
+ * @returns {(React.ComponentClass<P & { routeData: T }, S>)} tbe wrapped component
+ */
+export function withRouteData<T extends unknown = any, P extends object = {}, S extends object = {}>(
+  Comp: React.ComponentType<P>
+):  React.ComponentClass<P & { routeData: T }, S>;
+
+/**
+ * Component with a render function prop as children, which receives the current
+ * `routeData` as its only argument.
+ *
+ * @see useRouteData
+ *
+ * @template T type of the routedata
+ * @param {{ children: (routeData: T) => React.ReactNode }} props
+ * @returns {React.ReactNode}
+ */
+export function RouteData<T extends unknown = any>(
+  props: RouteDataProps<T>
+): React.ReactNode
+
+/**
+ * HOC that passes the `siteData` as a prop to the wrapped `Component`
+ *
+ * @see useSiteData
+ *
+ * @template T type of the siteData
+ * @template P type of the props of the original `Component`
+ * @template S type of the state of the original `Component`
+ *
+ * @param {React.ComponentType<P>} Comp the component to wrap
+ * @returns {(React.ComponentClass<P & { siteData: T }, S>)} tbe wrapped component
+ */
+export function witeSiteData<T extends unknown = any, P extends object = {}, S extends object = {}>(
+  Comp: React.ComponentType<P>
+):  React.ComponentClass<P & { routeData: T }, S>;
+
+/**
+ * Component with a render function prop as children, which receives the current
+ * `siteData` as its only argument.
+ *
+ * @see useSiteData
+ *
+ * @template T type of the routedata
+ * @param {{ children: (siteData: T) => React.ReactNode }} props
+ * @returns {React.ReactNode}
+ */
+export function SiteData<T extends unknown = any>(
+  props: SiteDataProps<T>
+): React.ReactNode
+
+/**
+ * The root component for a `react-static` app
+ */
+export class Root extends React.Component {}
+
+/**
+ * Routes component to render all routes
+ *
+ * React Static handles all of your routing for you using a router under the
+ * hood. All you need to do is import `Routes` and specify where you want to
+ * render them. (see first example).
+ *
+ * Occasionally, you may need to render the automatic `<Routes>` component in a
+ * custom way. The most common use-case is illustrated in the animated-routes
+ * example transitions. To do this, utilize a render prop. (see second example).
+ *
+ * @example handle all the routes in `react-static`
+ *
+ *   import { Root, Routes } from 'react-static'
+ *   export default () => (<Root>
+ *     <Router>
+ *        <Routes path="*" />
+ *     </Router>
+ *   </Root>)
+ *
+ * @example handle the routes manually
+ *
+ *   export default () => (<Root>
+ *     <Routes>
+ *       {({ getComponentForPath }) => {
+ *         // The pathname is used to retrieve the component for that path
+ *         let Comp = getComponentForPath(window.location.href)
+ *         // The component is rendered!
+ *         return <Comp />
+ *       }}
+ *     </Routes>
+ *  </Root>)
+ *
+ */
+export class Routes extends React.Component<{
+  path?: string,
+  default?: boolean,
+  children?: (props: RoutesRenderProp) => React.ReactNode
+}> {}
+
+// Export all from the browser types; since those are the only things typed
+export * from './browser'
+
+type AnyReactComponent = React.ComponentType<Record<string, any>>
+
+
+/**
+ * @see https://github.com/nozzle/react-static/blob/master/docs/config.md
+ */
+export interface ReactStaticConfig {
+  /**
+   * Your siteRoot in the format of `protocol://domain.com` is highly
+   * recommended and is necessary for many things related to SEO to function
+   * for your site. So far, this includes:
+   *
+   * - Automatically generating a `sitemap.xml` on export
+   * - Forcing absolute URLs in statically rendered links. Make sure that you
+   *   include https if you serve your site with it (which we highly recommend).
+   *   **Any trailing slashes including the pathname will be removed automatically**.
+   *   If you need to set a base path for your site (eg. if you're using GitHub
+   *   pages), you'll want to use the `basePath` option.
+   */
+  siteRoot?: string
 
   /**
-   * @see https://github.com/nozzle/react-static/blob/master/docs/config.md
+   * Works exactly like `siteRoot`, but only when building with the
+   * `--staging` build flag.
    */
-  export interface ReactStaticConfig {
-    siteRoot?: string
-    stagingSiteRoot?: string
-    basePath?: string
-    stagingBasePath?: string
-    devBasePath?: string
-    assetsPath?: string
-    extractCssChunks?: boolean
-    inlineCss?: boolean
-    disablePreload?: boolean
-    outputFileRate?: number
-    prefetchRate?: number
-    maxThreads?: number
-    minLoadTime?: number
-    disableRoutePrefixing?: boolean
-    paths?: PathsConfig
-    babelExcludes?: RegExp[]
-    devServer?: WebpackDevServerConfig
-    plugins?: Array<string | [string, object]>
-    Document?: AnyReactComponent
-    getRoutes?(flags: RouteFlags): Route[]
-    getSiteData?(flags: RouteFlags): any
-  }
+  stagingSiteRoot?: string
 
-  export interface PathsConfig {
-    root?: string
-    src?: string
-    temp?: string
-    dist?: string
-    devDist?: string
-    public?: string
-    assets?: string
-    pages?: string
-    plugins?: string
-    nodeModules?: string
-  }
+  /**
+   * Your basePath in the format of some/route is necessary if you intend on
+   * hosting your app from a specific route on your domain (eg. When using
+   * Github Pages or for example: https://mysite.com/blog where blog would the
+   * `basePath`)
+   *
+   * **All leading and trailing slashes are removed automatically**.
+   */
+  basePath?: string
 
-  export interface RouteFlags {
-    stage: string
-  }
+  /**
+   * Works exactly like `basePath`, but only when building with the
+   * `--staging` build flag.
+   */
+  stagingBasePath?: string
 
-  export interface Route {
-    path: string
-    template?: string
-    redirect?: string
-    children?: Route[]
-    getData?(resolvedRoute: Route, flags: RouteFlags): any
-    replace: boolean
-  }
+  /**
+   * Works exactly like `basePath`, but only when running the dev server.
+   */
+  devBasePath?: string
 
-  export interface DocumentProps {
-    Html: AnyReactComponent
-    Head: AnyReactComponent
-    Body: AnyReactComponent
-    children: ReactNodeArray
-    state: any // TODO: This should be changed
-  }
+  /**
+   * Your `assetsPath` determines where your bundled JS and CSS will be loaded
+   * from. This is helpful if you want to host your assets in an external
+   * location such as a CDN.
+   */
+  assetsPath?: string
 
-  export interface OnStartArgs {
-    devServerConfig: Readonly<WebpackDevServerConfig>
+  /**
+   * `extractCssChunks` replaces default `ExtractTextPlugin` with
+   * `ExtractCssChunks`. It enables automatic CSS splitting into separate files
+   * by routes as well as dynamic components (using
+   * `react-universal-component`).
+   *
+   * @see https://github.com/faceyspacey/extract-css-chunks-webpack-plugin
+   *   More information about the plugin and why it is useful as a part of CSS
+   *   delivery optimisation.
+   *
+   * @default false
+   */
+  extractCssChunks?: boolean
+
+  /**
+   * By using `extractCssChunks` option and putting code splitting at
+   * appropriate places, your page related CSS file can be minimal. This option
+   * allows you to inline your page related CSS in order to speed up your
+   * application by reducing the number of requests required for a first paint.
+   *
+   * @default false
+   */
+  inlineCss?: boolean
+
+  /**
+   * Set this boolean to true to disable all preloading. This is mostly meant
+   * for debugging at this point, but the internal mechanics could soon be
+   * converted into a condition to either preload or not based on the client
+   * (mobile, slow-connection, etc)
+   *
+   * @default false
+   */
+  disablePreload?: boolean
+
+  /**
+   * The maximum number of files that can be concurrently written to disk during
+   * the build process.
+   */
+  outputFileRate?: number
+
+  /**
+   * The maximum number of inflight requests for preloading route data on the
+   * client.
+   */
+  prefetchRate?: number
+
+  /**
+   * An optional Number of maximum threads to use when exporting your site's
+   * pages. By default this is set to Infinity to use all available threads on
+   * the machine React Static is running on.
+   *
+   * _NOTE: This only affects the process that are rendering your pages to html
+   * files, not the initial bundling process._
+   */
+  maxThreads?: number
+
+  /**
+   * An optional Number of milliseconds to show the loading spinner when
+   * templates, siteData or routeData are not immediately available. If you are
+   * preloading aggressively, you shouldn't see a loader at all, but if a loader
+   * is shown, it's a good user experience to make is as un-flashy as possible.
+   */
+  minLoadTime?: number
+
+  /**
+   * Set to true to disable prefixing link href values and the browser history
+   * with `config.basePath`. Useful if you are using a variable basePath such as
+   * `/country/language/basePath`.
+   *
+   * @default false
+   */
+  disableRoutePrefixing?: boolean
+
+  /**
+   * Set to true to disable warnings of duplicate routes during builds.
+   *
+   * @default false
+   */
+  disableDuplicateRoutesWarning?: boolean
+
+  /**
+   * An object of internal directories used by react-static that can be customized.
+   * Each path is relative to your project root.
+   */
+  paths?: PathsConfig
+
+  /**
+   * We are running Babel seperately for your own sources and externals. The
+   * Babel configuration for your own sources can be manipulated the normal way.
+   * The one for `node_modules` can not, since it's a bit special. We try to
+   * compile them with a bare minimum, but sometimes some modules gives you
+   * trouble (e.g. `mapbox-gl`)
+   *
+   * This option gives you the ability to exclude some modules from babelifying.
+   * See https://webpack.js.org/configuration/module/#condition for more
+   * details.
+   *
+   * @example To exclude e.g. `mapboxgl`
+   *
+   *   export default {
+   *     babelExcludes: [/mapbox-gl/],
+   *   }
+   */
+  babelExcludes?: RegExp[]
+
+  /**
+   * An `Object` of options to be passed to the underlying
+   * `webpack-dev-server` instance used for development.
+   */
+  devServer?: WebpackDevServerConfig
+
+  /**
+   * Set this flag to true to include source maps in production.
+   *
+   * @default false
+   */
+  productionSourceMaps?: boolean
+
+  /**
+   * It's never been easier to customize the root document of your website!
+   * `Document` is an optional (and again, recommended) react component
+   * responsible for rendering the HTML shell of your website.
+   *
+   * Things you may want to place here:
+   *
+   * - Site-wide custom head and/or meta tags
+   * - Site-wide analytics scripts
+   * - Site-wide stylesheets
+   */
+  Document?: DocumentComponent
+
+  /**
+   * An asynchronous function that should resolve an array of route objects.
+   * You'll probably want to use this function to request any dynamic data or
+   * information that is needed to build all of the routes for your site. It is
+   * also passed an object containing a dev boolean indicating whether it's
+   * being run in a production build or not.
+   *
+   * @param {RouteFlags} flags
+   * @returns {Promise<Route[]>} the promise that resolves the site data
+   */
+  getRoutes?(flags: RouteFlags): Promise<Route[]>
+
+  /**
+   * `getSiteData` is very similar to a route's getData function, but its result
+   * is made available to the entire site via the `SiteData` and `useSiteData`
+   * component/HOC. Any data you return here, although loaded once per session,
+   * will be embedded in every page that is exported on your site. So tread
+   * lightly ;)
+   *
+   * @template T the type of the site data
+   * @param {RouteFlags} flags
+   * @returns {Promise<T>} the promise that resolves the site data
+   */
+  getSiteData?<T extends unknown = any>(flags: RouteFlags): Promise<T>
+
+  plugins?: Array<PluginConfiguration>
+}
+
+export type PluginConfiguration = string | [string, object]
+
+export interface RouteFlags {
+  stage: 'dev' | 'prod'
+  debug?: boolean
+  isBuildCommand?: boolean
+  staging?: boolean
+  incremental?: boolean
+}
+
+/**
+ * A route is an object that represents a unique location in your site and is
+ * the backbone of every React-Static site.
+ */
+export interface Route {
+  /**
+   * The path of the URL to match for this route, excluding search parameters
+   * and hash fragments, relative to your siteRoot + basePath (if this is a
+   * child route, also relative to this route's parent path)
+   */
+  path: string
+
+  /**
+   * The path of the component to be used to render this route. (Relative to the
+   * root of your project)
+   */
+  template?: string
+
+  /**
+   * Setting this to a URL will perform the equivalent of a 301 redirect (as
+   * much as is possible within a static site) using http-equiv meta tags,
+   * canonicals, etc. This will force the page to render only the bare minimum
+   * to perform the redirect and nothing else.
+   */
+  redirect?: URL
+
+  /**
+   * Routes can and should have nested routes when necessary. Route paths are
+   * inherited as they are nested, so there is no need to repeat a path prefix
+   * in nested routes.
+   */
+  children?: Route[]
+
+  /**
+   * An async function that returns or resolves an object of any necessary data
+   * for this route to render.
+   *
+   * @template T type of the route data
+   * @param {Route} resolvedRoute This is the resolved route this function is handling.
+   * @param {RouteFlags} flags An object of flags and meta information about the build
+   * @returns {T} the route data
+   */
+  getData?<T extends unknown = any>(resolvedRoute: Route, flags: RouteFlags): Promise<T>
+
+  replace?: boolean
+}
+
+export interface PathsConfig {
+  /** @default process.cwd() */
+  root?: string
+  /** @default 'src' */
+  src?: string
+  /** @default 'tmp' */
+  temp?: string
+  /** @default 'dist' */
+  dist?: string
+  /** @default 'tmp/dev-server' */
+  devDist?: string
+  /** @default 'public' */
+  public?: string
+  /** @default 'dist' */
+  assets?: string
+  /** @default 'artifacts' */
+  buildArtifacts?: string
+  pages?: string
+  plugins?: string
+  nodeModules?: string
+}
+
+export type DocumentComponent<T extends unknown = any> = React.ComponentType<DocumentProps<T>>
+
+export interface DocumentProps<T extends unknown = any> {
+  Html: JSX.IntrinsicElements['html']
+  Head: JSX.IntrinsicElements['head']
+  Body: JSX.IntrinsicElements['body']
+  children: React.ReactNode
+  state: {
+    siteData: T
+    routeInfo: unknown
+    renderMeta: unknown
   }
 }
+
+export interface OnStartArgs {
+  devServerConfig: Readonly<WebpackDevServerConfig>
+}
+
+/**
+ * This function is for extracting a routePath from a path or string as
+ * RoutePaths do not have query params, basePaths, and should resemble the same
+ * string as passed in the static.config.js routes.
+ *
+ * You can use this to sanitize the pathname of a location before giving it to
+ * a custom `routePathContext.Provider`.
+ *
+ * @see routePathContext
+ *
+ * @param {string} routePath the unsanitized path
+ * @returns {string} the sanitized path
+ */
+export function getRoutePath(routePath: string): string
+
+/**
+ * Utility function to turn any path into an absolute path
+ *
+ * @private
+ *
+ * @param {string} path the potentially non-absolute path
+ * @returns {string} the absolute equivalent
+ */
+export function makePathAbsolute(path: string): string
+
+/**
+ * Utility function to join paths, making sure there are no double slashses
+ *
+ * @private
+ *
+ * @param {...ReadonlyArray<string>} paths the paths to join
+ * @returns {string} the joined path
+ */
+export function pathJoin(...paths: ReadonlyArray<string>): string

--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -17,6 +17,7 @@ interface StaticInfo<T extends object> {
 }
 
 interface RoutesRenderProp {
+  routePath: string
   getComponentForPath(pathname: string): React.ReactNode | false
 }
 
@@ -55,6 +56,12 @@ interface SiteDataProps<T extends object> {
  *   }
  *
  * @example Getting the route data _oustide_ the container / page / `Routes`
+ *
+ *   // This needs additional code to work properly in production, because there
+ *   // the useStaticInfo must be used to "hydrate" this data as Suspending is
+ *   // not allowed in production.
+ *
+ *   // You might just want to use `render` prop in `Routes` instead.
  *
  *   function Outside(): JSX.Element {
  *     const currentPath = getRoutePath(location.pathName)
@@ -261,9 +268,9 @@ export class Root extends React.Component {}
  *
  *   export default () => (<Root>
  *     <Routes>
- *       {({ getComponentForPath }) => {
+ *       {({ routePath, getComponentForPath }) => {
  *         // The pathname is used to retrieve the component for that path
- *         let Comp = getComponentForPath(window.location.href)
+ *         let Comp = getComponentForPath(routePath)
  *         // The component is rendered!
  *         return <Comp />
  *       }}
@@ -274,7 +281,7 @@ export class Root extends React.Component {}
 export class Routes extends React.Component<{
   path?: string,
   default?: boolean,
-  children?: (props: RoutesRenderProp) => React.ReactNode
+  render?: (props: RoutesRenderProp) => React.ReactNode
 }> {}
 
 // Export all from the browser types; since those are the only things typed
@@ -530,7 +537,7 @@ export interface Route {
    * canonicals, etc. This will force the page to render only the bare minimum
    * to perform the redirect and nothing else.
    */
-  redirect?: URL
+  redirect?: URL | string
 
   /**
    * Routes can and should have nested routes when necessary. Route paths are

--- a/packages/react-static/src/index.js
+++ b/packages/react-static/src/index.js
@@ -10,7 +10,7 @@ export { default as usePrefetch } from './browser/hooks/usePrefetch'
 export { default as useLocation } from './browser/hooks/useLocation'
 export { default as useBasepath } from './browser/hooks/useBasepath'
 export { useStaticInfo } from './browser/hooks/useStaticInfo'
-export { useRoutePath } from './browser/hooks/useRoutePath'
+export { useRoutePath, routePathContext } from './browser/hooks/useRoutePath'
 export { RouteData, withRouteData } from './browser/components/RouteData'
 export { SiteData, withSiteData } from './browser/components/SiteData'
 export {


### PR DESCRIPTION
## Description

This PR started because I needed `useRouteData` _outside_ of the `Routes` component tree. The missing piece was exporting the `routePathContext` context so that a context could be provided everywhere.

When making this change I constantly had to go back to the definitions to figure out what was what. So this PR has the following:
- add `routePathContext` to the exports
- change all the typings (fix missing, incorrect or incomplete typings) (fixes #1163)
- add descriptions to all the `public` functions in the typings
- add back `Routes` `renderProp`, but as render prop, so that the plugins don't break!

⚠️ This is a breaking change. Many of the types I've updated or added are _way_ more strict than the old types. This will probably catch bugs; I don't know if they're _too_ strict. ⚠️

My recommendation is to release it as a `feature` release; even though semantically it should be major. TS is not a first-class citizen yet in terms of react-static, so treating that change as a bugfix and the addition of the context as the feature should be okay.

> **Version 7.0 CHANGELOG**
> The child renderer and corresponding getComponentForPath utility previously provided via the Routes component has been deprecated.

📌 this adds back `getComponentForPath` in `Routes`, but not as `children`. The functionality was not compatible with the plugin system (as `Router` plugins may mutate `children`). Instead it's added as a `render` prop. The reason I added this back is because the `Routes` component does not play well when you want to put something in-between the "Outer" and "Inner" component. Yes, it can be solved with a plugin but this is non-trivial to do.

This enables the following code and also fixes #1153.
```tsx
function App() {
  return (
    <Root>
      <Suspense fallback={<em>Loading...</em>}>
        <Router>
          <Routes default render={
            ({ routePath, getComponentForPath }): React.ReactNode => {
              const Comp = getComponentForPath(routePath)
              return (
                <Wrapper>{Comp}</Wrapper>
              )}
            } />
        </Router>
      </Suspense>
    </Root>
  )
}
```

🚧 Note that I have _only_ tested this with `reach-router`. Can  someone please pull this and test with `react-router`?

## Screenshots (if appropriate):

This shows commentary on all the typings:

![typings with commentary](https://user-images.githubusercontent.com/1964376/57588747-25c7e400-7519-11e9-83a7-9e0872418d0c.png)

And can now be used to not only validate but also auto-complete the config:

![typing the configuration](https://user-images.githubusercontent.com/1964376/57588830-a76c4180-751a-11e9-843c-24ae9e04787b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
