### PR TITLE
Fix publicPath handling

### DIFF
--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -35,7 +35,7 @@ export default function({ config }) {
       filename: '[name].js', // never hash dev code
       chunkFilename: 'templates/[name].js',
       path: DIST,
-      publicPath: process.env.REACT_STATIC_ASSETS_PATH || '/',
+      publicPath: process.env.REACT_STATIC_PUBLIC_PATH || '/',
     },
     module: {
       rules: rules({ config, stage: 'dev' }),

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -80,7 +80,7 @@ function common(state) {
       filename: '[name].[hash:8].js', // dont use chunkhash, its not a chunk
       chunkFilename: 'templates/[name].[chunkHash:8].js',
       path: ASSETS,
-      publicPath: process.env.REACT_STATIC_ASSETS_PATH || '/',
+      publicPath: process.env.REACT_STATIC_PUBLIC_PATH || '/',
     },
     optimization: {
       sideEffects: true,


### PR DESCRIPTION
`publicPath` should be read from `REACT_STATIC_PUBLIC_PATH` and not from `REACT_STATIC_ASSETS_PATH`.

Fixes #1141.