### PR TITLE
Limit added to node fileloader rule to prevent all images from being inlined as base64 strings,

### DIFF
--- a/packages/react-static/src/static/webpack/rules/fileLoader.js
+++ b/packages/react-static/src/static/webpack/rules/fileLoader.js
@@ -3,6 +3,9 @@ export default function({ stage, isNode }) {
     return {
       loader: 'url-loader',
       exclude: [/\.js$/, /\.html$/, /\.json$/],
+      options: {
+        limit: 10000,
+      }
       // Don't generate extra files during node build
     }
   }


### PR DESCRIPTION
## Description

The webpack file-loader rule for node didn't have a limit, this caused the actual generated files to never include the url for the image file and instead inline everything as a base64.

## Changes/Tasks

- [x] Changed code

## Motivation and Context

Should fix: 
#1221 and somewhat resolve the issue in #1157 

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
