### PR TITLE
Use 'overrideBrowserslist' option instead of 'browsers' in autoprefixer

### DIFF
--- a/packages/react-static-plugin-less/package.json
+++ b/packages/react-static-plugin-less/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.4.3"
   },
   "dependencies": {
-    "autoprefixer": "^9.5.1",
+    "autoprefixer": "^9.6.0",
     "css-loader": "^2.1.0",
     "extract-css-chunks-webpack-plugin": "^4.5.1",
     "less": "^3.9.0",

--- a/packages/react-static-plugin-less/package.json
+++ b/packages/react-static-plugin-less/package.json
@@ -24,5 +24,11 @@
     "postcss-flexbugs-fixes": "^4.1.0",
     "semver": "^6.0.0"
   },
+  "browserslist": [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
   "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4"
 }

--- a/packages/react-static-plugin-less/src/node.api.js
+++ b/packages/react-static-plugin-less/src/node.api.js
@@ -29,7 +29,7 @@ export default ({ includePaths = [], ...rest }) => ({
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            browsers: [
+            overrideBrowserslist: [
               '>1%',
               'last 4 versions',
               'Firefox ESR',

--- a/packages/react-static-plugin-less/src/node.api.js
+++ b/packages/react-static-plugin-less/src/node.api.js
@@ -29,12 +29,6 @@ export default ({ includePaths = [], ...rest }) => ({
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            overrideBrowserslist: [
-              '>1%',
-              'last 4 versions',
-              'Firefox ESR',
-              'not ie < 9', // React doesn't support IE8 anyway
-            ],
             flexbox: 'no-2009',
           }),
         ],

--- a/packages/react-static-plugin-sass/package.json
+++ b/packages/react-static-plugin-sass/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-env": "^7.4.3"
   },
   "dependencies": {
-    "autoprefixer": "^9.5.1",
+    "autoprefixer": "^9.6.0",
     "css-loader": "^2.1.0",
     "extract-css-chunks-webpack-plugin": "^4.5.1",
     "node-sass": "^4.11.0",

--- a/packages/react-static-plugin-sass/package.json
+++ b/packages/react-static-plugin-sass/package.json
@@ -28,5 +28,11 @@
     "sass-loader": "^7.1.0",
     "semver": "^6.0.0"
   },
+  "browserslist": [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
   "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4"
 }

--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -28,7 +28,7 @@ export default ({ includePaths = [], ...rest }) => ({
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            browsers: [
+            overrideBrowserslist: [
               '>1%',
               'last 4 versions',
               'Firefox ESR',

--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -28,12 +28,6 @@ export default ({ includePaths = [], ...rest }) => ({
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            overrideBrowserslist: [
-              '>1%',
-              'last 4 versions',
-              'Firefox ESR',
-              'not ie < 9', // React doesn't support IE8 anyway
-            ],
             flexbox: 'no-2009',
           }),
         ],

--- a/packages/react-static-plugin-stylus/package.json
+++ b/packages/react-static-plugin-stylus/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.4.3"
   },
   "dependencies": {
-    "autoprefixer": "^9.5.1",
+    "autoprefixer": "^9.6.0",
     "css-loader": "^2.1.0",
     "extract-css-chunks-webpack-plugin": "^4.3.2",
     "nib": "^1.1.2",

--- a/packages/react-static-plugin-stylus/package.json
+++ b/packages/react-static-plugin-stylus/package.json
@@ -25,5 +25,11 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2"
   },
+  "browserslist": [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
   "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4"
 }

--- a/packages/react-static-plugin-stylus/src/node.api.js
+++ b/packages/react-static-plugin-stylus/src/node.api.js
@@ -34,12 +34,6 @@ export default ({ cssLoaderOptions, ...rest }) => ({
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            overrideBrowserslist: [
-              '>1%',
-              'last 4 versions',
-              'Firefox ESR',
-              'not ie < 9', // React doesn't support IE8 anyway
-            ],
             flexbox: 'no-2009',
           }),
         ],

--- a/packages/react-static-plugin-stylus/src/node.api.js
+++ b/packages/react-static-plugin-stylus/src/node.api.js
@@ -34,7 +34,7 @@ export default ({ cssLoaderOptions, ...rest }) => ({
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            browsers: [
+            overrideBrowserslist: [
               '>1%',
               'last 4 versions',
               'Firefox ESR',

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -42,7 +42,7 @@
     "@babel/register": "^7.4.0",
     "@babel/runtime": "^7.4.3",
     "@reach/router": "^1.2.1",
-    "autoprefixer": "^9.5.1",
+    "autoprefixer": "^9.6.0",
     "axios": "^0.18.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-loader": "^8.0.0",

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -66,7 +66,7 @@
     "inquirer": "^6.3.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "intersection-observer": "^0.5.1",
-    "jsesc" : "^2.5.2",
+    "jsesc": "^2.5.2",
     "match-sorter": "^3.0.0",
     "minimist": "^1.2.0",
     "mutation-observer": "^1.0.3",
@@ -128,6 +128,12 @@
     "rimraf": "^2.6.2",
     "webpack-hot-middleware": "^2.24.3"
   },
+  "browserslist": [
+    ">1%",
+    "last 4 versions",
+    "Firefox ESR",
+    "not ie < 9"
+  ],
   "jest": {
     "verbose": true,
     "moduleDirectories": [

--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -21,12 +21,6 @@ function initCSSLoader() {
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            overrideBrowserslist: [
-              '>1%',
-              'last 4 versions',
-              'Firefox ESR',
-              'not ie < 9', // React doesn't support IE8 anyway
-            ],
             flexbox: 'no-2009', // I'd opt in for this - safari 9 & IE 10.
           }),
         ],

--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -21,7 +21,7 @@ function initCSSLoader() {
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            browsers: [
+            overrideBrowserslist: [
               '>1%',
               'last 4 versions',
               'Firefox ESR',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3200,17 +3200,18 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^9.5.1:
-  version "9.5.1"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.5.1.tgz#243b1267b67e7e947f28919d786b50d3bb0fb357"
-  integrity sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==
+autoprefixer@^9.6.0:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.6.1.tgz#51967a02d2d2300bb01866c1611ec8348d355a47"
+  integrity sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==
   dependencies:
-    browserslist "^4.5.4"
-    caniuse-lite "^1.0.30000957"
+    browserslist "^4.6.3"
+    caniuse-lite "^1.0.30000980"
+    chalk "^2.4.2"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^7.0.14"
-    postcss-value-parser "^3.3.1"
+    postcss "^7.0.17"
+    postcss-value-parser "^4.0.0"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -3648,7 +3649,7 @@ browserslist@^4.5.1:
     electron-to-chromium "^1.3.116"
     node-releases "^1.1.11"
 
-browserslist@^4.5.2, browserslist@^4.5.4:
+browserslist@^4.5.2:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.5.tgz#fe1a352330d2490d5735574c149a85bc18ef9b82"
   integrity sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==
@@ -3656,6 +3657,15 @@ browserslist@^4.5.2, browserslist@^4.5.4:
     caniuse-lite "^1.0.30000960"
     electron-to-chromium "^1.3.124"
     node-releases "^1.1.14"
+
+browserslist@^4.6.3:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.4.tgz#fd0638b3f8867fec2c604ed0ed9300379f8ec7c2"
+  integrity sha512-ErJT8qGfRt/VWHSr1HeqZzz50DvxHtr1fVL1m5wf20aGrG8e1ce8fpZ2EjZEfs09DDZYSvtRaDlMpWslBf8Low==
+  dependencies:
+    caniuse-lite "^1.0.30000981"
+    electron-to-chromium "^1.3.188"
+    node-releases "^1.1.25"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -3888,10 +3898,15 @@ caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000951:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000953.tgz#8054c4e5c4aa69dc3269353a4a5e102909759dbb"
   integrity sha512-2stdF/q5MZTDhQ6uC65HWbSgI9UMKbc7+HKvlwH5JBIslKoD/J9dvabP4J4Uiifu3NljbHj3iMpfYflLSNt09A==
 
-caniuse-lite@^1.0.30000957, caniuse-lite@^1.0.30000960:
+caniuse-lite@^1.0.30000960:
   version "1.0.30000962"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz#6c10c3ab304b89bea905e66adf98c0905088ee44"
   integrity sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==
+
+caniuse-lite@^1.0.30000980, caniuse-lite@^1.0.30000981:
+  version "1.0.30000981"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000981.tgz#5b6828803362363e5a1deba2eb550185cf6cec8f"
+  integrity sha512-JTByHj4DQgL2crHNMK6PibqAMrqqb/Vvh0JrsTJVSWG4VSUrT16EklkuRZofurlMjgA9e+zlCM4Y39F3kootMQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5486,6 +5501,11 @@ electron-to-chromium@^1.3.124:
   version "1.3.125"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz#dbde0e95e64ebe322db0eca764d951f885a5aff2"
   integrity sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==
+
+electron-to-chromium@^1.3.188:
+  version "1.3.188"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.188.tgz#e28e1afe4bb229989e280bfd3b395c7ec03c8b7a"
+  integrity sha512-tEQcughYIMj8WDMc59EGEtNxdGgwal/oLLTDw+NEqJRJwGflQvH3aiyiexrWeZOETP4/ko78PVr6gwNhdozvuQ==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -8610,7 +8630,7 @@ jsdom@^11.5.1:
     ws "^5.2.0"
     xml-name-validator "^3.0.0"
 
-jsesc@^2.5.1:
+jsesc@^2.5.1, jsesc@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
@@ -9761,6 +9781,13 @@ node-releases@^1.1.14:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.15.tgz#9e76a73b0eca3bf7801addaa0e6ce90c795f2b9a"
   integrity sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==
+  dependencies:
+    semver "^5.3.0"
+
+node-releases@^1.1.25:
+  version "1.1.25"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.25.tgz#0c2d7dbc7fed30fbe02a9ee3007b8c90bf0133d3"
+  integrity sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==
   dependencies:
     semver "^5.3.0"
 
@@ -11045,10 +11072,24 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
+postcss-value-parser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz#99a983d365f7b2ad8d0f9b8c3094926eab4b936d"
+  integrity sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==
+
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
   integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.17:
+  version "7.0.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.17.tgz#4da1bdff5322d4a0acaab4d87f3e782436bad31f"
+  integrity sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As of [autoprefixer@9.6.0](https://github.com/postcss/autoprefixer/releases/tag/9.6.0), autoprefixer recommends to use a `.browserslistrc` file or a `browserslist` attribute in package.json. Currently, if you try to run or build a react-static project, it will [warn you and tell you to do the above (#1220)](https://github.com/nozzle/react-static/issues/1220).

If we remove the `browsers` option in the autoprefixer, this will introduce a breaking change as consumers will need to create a browserslist config. For now, I have renamed the `browsers` option to `overrideBrowserslist` to avoid any breaking changes, and in the next major React Static release, maybe we remove this option in favour of the browserslist config file. Keen to hear your thoughts!

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Rename `browsers` option to `overrideBrowserslist` in the autoprefixer config.
- [x] Update autoprefixer to ^9.6.0

## Motivation and Context

Solves #1220.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
