### PR TITLE
Don't use a relative path to resolve Default404 template

### DIFF
--- a/packages/react-static/src/static/components/BodyWithMeta.js
+++ b/packages/react-static/src/static/components/BodyWithMeta.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import { pathJoin, makePathAbsolute } from '../../utils'
 import jsesc from 'jsesc';
+import { pathJoin, makePathAbsolute } from '../../utils'
 
 const generateRouteInformation = embeddedRouteInfo => ({
   __html: `

--- a/packages/react-static/src/static/components/__tests__/__snapshots__/BodyWithMeta.test.js.snap
+++ b/packages/react-static/src/static/components/__tests__/__snapshots__/BodyWithMeta.test.js.snap
@@ -13,7 +13,7 @@ exports[`BodyWithMeta when route is a redirect route 1`] = `
     </div>
   </body>
 </Component>
-`
+`;
 
 exports[`BodyWithMeta when route is a static route 1`] = `
 <Component
@@ -30,7 +30,7 @@ exports[`BodyWithMeta when route is a static route 1`] = `
       dangerouslySetInnerHTML={
         Object {
           "__html": "
-    window.__routeInfo = {\\"routeDate\\":\\"here\\"};",
+    window.__routeInfo = JSON.parse(\\"{\\\\\\"routeDate\\\\\\":\\\\\\"here\\\\\\"}\\");",
         }
       }
       type="text/javascript"
@@ -49,4 +49,4 @@ exports[`BodyWithMeta when route is a static route 1`] = `
     />
   </body>
 </Component>
-`
+`;

--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -17,9 +17,7 @@ export default (async function extractTemplates(state) {
       return
     }
 
-    route.template = slash(
-      path.resolve(config.paths.ARTIFACTS, route.template)
-    )
+    route.template = slash(path.resolve(config.paths.ARTIFACTS, route.template))
 
     // Check if the template has already been added
     const index = templates.indexOf(route.template)

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -124,15 +124,15 @@ export function buildConfig(state, config = {}) {
   let assetsPath = ''
   if (process.env.REACT_STATIC_ENV === 'development') {
     basePath = cleanSlashes(config.devBasePath)
-    assetsPath = config.devAssetsPath || paths.assets
+    assetsPath = config.devAssetsPath || paths.assets || assetsPath
   } else if (state.staging) {
     siteRoot = cutPathToRoot(config.stagingSiteRoot || '/', '$1')
     basePath = cleanSlashes(config.stagingBasePath)
-    assetsPath = config.stagingAssetsPath || paths.assets
+    assetsPath = config.stagingAssetsPath || paths.assets || assetsPath
   } else {
     siteRoot = cutPathToRoot(config.siteRoot, '$1')
     basePath = cleanSlashes(config.basePath)
-    assetsPath = config.assetsPath || paths.assets
+    assetsPath = config.assetsPath || paths.assets || assetsPath
   }
   const publicPath = `${cleanSlashes(`${siteRoot}/${basePath}`)}/`
 
@@ -141,7 +141,7 @@ export function buildConfig(state, config = {}) {
   }
 
   // add trailing slash only if assetsPath was supplied, but no trailing slash
-  if (assetsPath !== '' && !assetsPath.endsWith('/')) {
+  if (assetsPath && !assetsPath.endsWith('/')) {
     assetsPath = `${assetsPath}/`
   }
 

--- a/packages/react-static/src/static/getRoutes.js
+++ b/packages/react-static/src/static/getRoutes.js
@@ -46,12 +46,9 @@ export default async function getRoutes(state, callback = d => d) {
     if (!has404 && !incremental) {
       allNormalizedRoutes.unshift({
         path: '404',
-        template: path.relative(
-          state.config.paths.ROOT,
-          path.resolve(
-            __dirname,
-            path.join('..', 'browser', 'components', 'Default404')
-          )
+        template: path.resolve(
+          __dirname,
+          path.join('..', 'browser', 'components', 'Default404')
         ),
       })
     }


### PR DESCRIPTION
The current approach assumes that the current directory when running
`react-static` is the root path, which might not be the case if you
customize the root.

This came up as I'm developing a CLI module that embeds `react-static`,
takes some command line arguments, spawns `react-static` using files
inside the CLI module, and stores the results in the user's destination
directory.

When the tool (and therefore `react-static`) are installed globally, my
`ROOT` is:

```
/Users/jviotti/.nvm/versions/node/v9.11.2/lib/node_modules/<my-cli>
```

And `__dirname` from `src/static/getRoutes.js` becomes:

```
/Users/jviotti/.nvm/versions/node/v9.11.2/lib/node_modules/<my-cli>/node_modules/react-static/lib/static
```

Given those two variables, the code in `getRoutes.js` will evaluate the
`Default404` template path to:

```
node_modules/react-static/lib/browser/components/Default404
```

Which is a relative path, therefore `react-static` will try to find
`Default404` in a local installation of `react-static` in the place the
user ran the CLI, which is not expected.

Making the path absolute ensures that `react-static` always defaults the
404 template to the one it itself ships, instead of accidentally cross
referencing another version of itself.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>