### PR TITLE
Fix route template path handling

### DIFF
--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -16,9 +16,11 @@ export default (async function extractTemplates(state) {
     if (!route.template) {
       return
     }
+
     route.template = slash(
-      path.relative(config.paths.ARTIFACTS, route.template)
+      path.resolve(config.paths.ARTIFACTS, route.template)
     )
+
     // Check if the template has already been added
     const index = templates.indexOf(route.template)
     if (index === -1) {


### PR DESCRIPTION
Consider that we store the artifacts on an OS temporary directory (such
as what you would get with `mktemp -d` or `node-tmp`) which we can
assume for simplicity purposes to be `/tmp/react-static`.

In the snippet above, `route.template` is a path such as
`/home/johndoe/site/lib/pages/main.js`. Therefore `path.relative()` will
calculate the path to `/home/johndoe/site/lib/pages/main.js` from
`/tmp/react-static`, so the result will be something like
`../home/johndoe/site/lib/pages/main.js` which makes no sense and will
cause react-static to fail.

What we really intended is `path.resolve()`, so that the user still gets
`/home/johndoe/site/lib/pages/main.js`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
