### PR TITLE
Don't use path.relative() in react-static/src/static

### DIFF
--- a/packages/react-static/src/static/generateBrowserPlugins.js
+++ b/packages/react-static/src/static/generateBrowserPlugins.js
@@ -24,7 +24,7 @@ export default async state => {
           : -1
         if (pluginIndex === -1 && browserLocation) {
           pluginImports.push(
-            slash(path.relative(config.paths.ARTIFACTS, browserLocation))
+            slash(path.resolve(config.paths.ARTIFACTS, browserLocation))
           )
           pluginIndex = pluginImports.length - 1
         }
@@ -33,7 +33,7 @@ export default async state => {
 
         // IIF to return the final plugin
         return `{
-        location: "${slash(path.relative(config.paths.ARTIFACTS, location))}",
+        location: "${slash(path.resolve(config.paths.ARTIFACTS, location))}",
         plugins: ${recurse(plugins || [])},
         hooks: ${
           browserLocation

--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -46,7 +46,7 @@ export default function({ config }) {
         NODE_MODULES,
         SRC,
         DIST,
-        ...[NODE_MODULES, SRC, DIST].map(d => path.relative(__dirname, d)),
+        ...[NODE_MODULES, SRC, DIST].map(d => path.resolve(__dirname, d)),
         'node_modules',
       ],
       extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx'],

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -119,7 +119,7 @@ function common(state) {
         SRC,
         DIST,
         ...[NODE_MODULES, SRC, DIST].map(d =>
-          DIST.startsWith(ROOT) ? path.relative(__dirname, d) : path.resolve(d)
+          DIST.startsWith(ROOT) ? path.resolve(__dirname, d) : path.resolve(d)
         ),
         'node_modules',
       ],


### PR DESCRIPTION
I've been lately hitting various issues due to the way react-static
defaults to relative paths, which tend to break as soon as you tweak
react-static directories (artifacts, dist, root, etc) to locations that
are not the ones react-static recommend.

Most of these issues are automatically resolved by switching to
`path.resolve()`, which always results in absolute paths, and avoids
large `../../` chains if the second argument is absolute.

See: https://github.com/nozzle/react-static/pull/1250
See: https://github.com/nozzle/react-static/pull/1253
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
