### PR TITLE
Allow plugins to use plugins

### DIFF
--- a/packages/react-static/src/static/plugins.js
+++ b/packages/react-static/src/static/plugins.js
@@ -102,4 +102,8 @@ export default {
     const hooks = getHooks(state.plugins, 'afterExport')
     return reduceHooks(hooks)(state)
   },
+  plugins: state => {
+    const hooks = getHooks(state.plugins, 'plugins')
+    return reduceHooks(hooks)(state)
+  },
 }

--- a/packages/react-static/src/static/plugins.js
+++ b/packages/react-static/src/static/plugins.js
@@ -18,6 +18,7 @@ const supportedHooks = [
   'beforeHtmlToDocument',
   'beforeDocumentToFile',
   'afterExport',
+  'plugins',
 ]
 
 export const validatePlugin = plugin => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Yo dawg, I heard you like plugins, so I added 'plugins' to plugins.js so you can use plugins while you write plugins.

## Changes/Tasks

- [x] Added 'plugins' to the list of supported hooks for plugins

## Motivation and Context

Fixes https://github.com/react-static/react-static/issues/1143

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
