### PR TITLE
Ensure publicPath is always absolute

### DIFF
--- a/packages/react-static/src/browser/utils/__tests__/shared.test.js
+++ b/packages/react-static/src/browser/utils/__tests__/shared.test.js
@@ -9,7 +9,7 @@ import {
   trimDoubleSlashes,
   makePathAbsolute,
   getFullRouteData,
-} from ".."
+} from '..'
 
 describe('browser/utils', () => {
   describe('pathJoin()', () => {
@@ -42,6 +42,10 @@ describe('browser/utils', () => {
 
     it('should return / for /', () => {
       expect(getRoutePath('/')).toEqual('/')
+    })
+
+    it('should return / for basePath', () => {
+      expect(getRoutePath('base/path')).toEqual('/')
     })
 
     it('should strip basePath', () => {

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -63,7 +63,11 @@ export function pathJoin(...paths) {
 // resemble the same string as passed in the static.config.js routes
 export function getRoutePath(routePath) {
   // Detect falsey paths and the root path
-  if (!routePath || routePath === '/') {
+  if (
+    !routePath ||
+    routePath === '/' ||
+    routePath === process.env.REACT_STATIC_BASE_PATH
+  ) {
     return '/'
   }
 

--- a/packages/react-static/src/static/__mocks__/defaultConfigProduction.mock.js
+++ b/packages/react-static/src/static/__mocks__/defaultConfigProduction.mock.js
@@ -1,5 +1,5 @@
 export default {
-  siteRoot: '',
+  siteRoot: '/',
   basePath: '',
   assetsPath: '',
   prefetchRate: 5,

--- a/packages/react-static/src/static/__tests__/getConfig.test.js
+++ b/packages/react-static/src/static/__tests__/getConfig.test.js
@@ -133,6 +133,26 @@ describe('buildConfig', () => {
       expect(config.assetsPath).toBe('https://example.com/assets/')
     })
   })
+
+  describe('publicPath is absolute', () => {
+    test('when user supplies a site root', () => {
+      const { config } = buildConfig({}, { siteRoot: 'http://example.com' })
+      expect(config.publicPath).toBe('http://example.com/')
+    })
+
+    test('when user supplies a basePath', () => {
+      const { config } = buildConfig({}, { basePath: 'dist' })
+      expect(config.publicPath).toBe('/dist/')
+    })
+
+    test('when user supplies a site root and a basePath', () => {
+      const { config } = buildConfig(
+        {},
+        { siteRoot: 'http://example.com', basePath: 'dist' }
+      )
+      expect(config.publicPath).toBe('http://example.com/dist/')
+    })
+  })
 })
 
 describe('getConfig', () => {

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -130,11 +130,13 @@ export function buildConfig(state, config = {}) {
     basePath = cleanSlashes(config.stagingBasePath)
     assetsPath = config.stagingAssetsPath || paths.assets || assetsPath
   } else {
-    siteRoot = cutPathToRoot(config.siteRoot, '$1')
+    siteRoot = cutPathToRoot(config.siteRoot || '/', '$1')
     basePath = cleanSlashes(config.basePath)
     assetsPath = config.assetsPath || paths.assets || assetsPath
   }
-  const publicPath = `${cleanSlashes(`${siteRoot}/${basePath}`)}/`
+  const publicPath = `${cleanSlashes(`${siteRoot}/${basePath}`, {
+    leading: false,
+  })}/`
 
   if (assetsPath && !isAbsoluteUrl(assetsPath)) {
     assetsPath = `/${cleanSlashes(`${basePath}/${assetsPath}`)}/`

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -80,7 +80,7 @@ function common(state) {
       filename: '[name].[hash:8].js', // dont use chunkhash, its not a chunk
       chunkFilename: 'templates/[name].[chunkHash:8].js',
       path: ASSETS,
-      publicPath: process.env.REACT_STATIC_ASSETS_PATH || '/',
+      publicPath: process.env.REACT_STATIC_PUBLIC_PATH || '/',
     },
     optimization: {
       sideEffects: true,


### PR DESCRIPTION
Fixes #1141.

Implements the changes discussed [here](https://github.com/react-static/react-static/pull/1196#discussion_r290831191) to ensure that `publicPath`/`process.env.REACT_STATIC_PUBLIC_PATH` is always absolute.

This also address the issue with the `getRoutePath` utility, ensuring it strips `basePath` when it's present.