### PR TITLE
Handle relative route template

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -47,7 +47,7 @@ A route is an `object` that represents a unique location in your site and is the
 It supports the following properties:
 
 - `path: String` - The **path** of the URL to match for this route, **excluding search parameters and hash fragments, relative to your `siteRoot + basePath` (if this is a child route, also relative to this route's parent path)**
-- `template: String` - The path of the component to be used to render this route. (Relative to the root of your project)
+- `template: String` - The path of the component to be used to render this route. (Relative to the root of your project or absolute)
 - `getData: async Function(resolvedRoute, { dev }) => Object` - An async function that returns or resolves an object of any necessary data for this route to render.
   - Arguments
     - `resolvedRoute: Object` - This is the resolved route this function is handling.

--- a/packages/react-static/src/static/__tests__/extractTemplates.test.js
+++ b/packages/react-static/src/static/__tests__/extractTemplates.test.js
@@ -44,3 +44,21 @@ test('the 404 template is the first one', async () => {
 
   expect(state.templates[0]).toContain('src/templates/404')
 })
+
+test('relative routes path resolves against the ROOT', async () => {
+  const { templates } = await extractTemplates({
+    config,
+    routes: [{ path: '404', template: './src/templates/NotFound' }],
+  })
+
+  expect(templates[0]).toBe(`${config.paths.ROOT}/src/templates/NotFound`)
+})
+
+test('absolute routes path are kept intact', async () => {
+  const { templates } = await extractTemplates({
+    config,
+    routes: [{ path: '404', template: '/home/src/templates/NotFound' }],
+  })
+
+  expect(templates[0]).toBe('/home/src/templates/NotFound')
+})

--- a/packages/react-static/src/static/__tests__/extractTemplates.test.js
+++ b/packages/react-static/src/static/__tests__/extractTemplates.test.js
@@ -1,0 +1,46 @@
+import extractTemplates from '../extractTemplates'
+
+const config = {
+  paths: {
+    ROOT: process.cwd(),
+  },
+}
+
+test('a 404 route is required when the build is not incremental', async () => {
+  expect.assertions(1)
+  try {
+    await extractTemplates({
+      config,
+      routes: [],
+      incremental: false,
+    })
+  } catch (error) {
+    expect(error.message).toBeTruthy()
+  }
+})
+
+test('a 404 route is not required when the build is incremental', async () => {
+  expect.assertions(1)
+  try {
+    const state = await extractTemplates({
+      config,
+      routes: [],
+      incremental: true,
+    })
+    expect(state).toBeTruthy()
+  } catch (_error) {
+    throw new Error()
+  }
+})
+
+test('the 404 template is the first one', async () => {
+  const state = await extractTemplates({
+    config,
+    routes: [
+      { path: '/', template: './src/templates/Homepage' },
+      { path: '404', template: './src/templates/404' },
+    ],
+  })
+
+  expect(state.templates[0]).toContain('src/templates/404')
+})

--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -24,6 +24,7 @@ export default (async function extractTemplates(state) {
     if (index === -1) {
       // If it's new, add it
       if (route.path === '404') {
+        // Make sure 404 template is the first one
         templates.unshift(route.template)
         notFoundPending = false
       } else {
@@ -39,7 +40,6 @@ export default (async function extractTemplates(state) {
     )
   }
 
-  // Make sure 404 template is the first one
   return {
     ...state,
     templates,

--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -17,7 +17,7 @@ export default (async function extractTemplates(state) {
       return
     }
 
-    route.template = slash(path.resolve(config.paths.ARTIFACTS, route.template))
+    route.template = slash(path.resolve(config.paths.ROOT, route.template))
 
     // Check if the template has already been added
     const index = templates.indexOf(route.template)


### PR DESCRIPTION
Implement fix discussed here: https://github.com/react-static/react-static/pull/1253#issuecomment-519566900.

> Per the current documentation, `route.template` should be relative to `static.config.js`/the root of the project - so with the change proposed, we'd keep this behavior, as well as support supplying an absolute path. The resulting `route.template` would however always be absolute, ensuring build artifacts can be stored outside of the repo.

I've added some tests around `extractTemplates`, I think some integration tests would probably be more useful here but didn't get to figure it out.

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
