### PR TITLE
Fix broken link in docs/plugins/README.md

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -25,9 +25,9 @@ React Static ships with a plugin API to extend React Static's functionality.
   - [react-static-plugin-source-filesystem](/packages/react-static-plugin-source-filesystem) - Creates routes from files in a directory
   - [react-static-plugin-mdx](/packages/react-static-plugin-mdx) - Adds support for MDX
 - Type checking
-  - [react-static-plugin-typescript](packages/react-static-plugin-typescript) - Allows you to write your components in TypeScript
+  - [react-static-plugin-typescript](/packages/react-static-plugin-typescript) - Allows you to write your components in TypeScript
 - Assets
-  - [react-static-plugin-sitemap](packages/react-static-plugin-sitemap) - Exports sitemap information as XML
+  - [react-static-plugin-sitemap](/packages/react-static-plugin-sitemap) - Exports sitemap information as XML
 
 ### Unofficial Plugins via NPM
 


### PR DESCRIPTION
## Description

Fixed broken link in [docs/plugins/README.md](https://github.com/react-static/react-static/blob/5a38e1c818ef57c94b01083ac120d592036f8afd/docs/plugins/README.md)

- react-static-plugin-typescript
- react-static-plugin-sitemap

## Changes/Tasks

- [x] Changed code

## Motivation and Context

- To improve document quality.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
