### PR TITLE
Add "Weekly Best of JavaScript" site to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ React-Static is a fast, lightweight, and powerful progressive static site genera
 - [Amplify Credit Union](https://www.goamplify.com)
 - [Rebel Breath](https://www.rebelbreath.com/)
 - [Fourth Drive - Music Artist](https://fourthdrive.com)  ([source](https://gitlab.com/galmargalit1/fourth-drive))
+- [Weekly Best of JavaScript](https://weekly.bestofjs.org/) ([source](https://github.com/bestofjs/bestofjs-weekly))
 
 ## Quick Start
 


### PR DESCRIPTION
Hello, thank you for your great work!

I'd like to add [Weekly Best of JavaScript](https://weekly.bestofjs.org/) to the list of sites made with _React Static_.

_Weekly Best of JavaScript_ is the the weekly newsletter from [Best of JavaScript](https://bestofjs.org/) application.

It's made with React Static 7, as you can see on [GitHub repo](https://github.com/bestofjs/bestofjs-weekly).

As a side note, _React Static_ is doing well on _Best of JavaScript_: https://bestofjs.org/projects/react-static

![image](https://user-images.githubusercontent.com/5546996/63134192-5c733600-c003-11e9-9e78-82880d9a90e1.png)

