### PR TITLE
Make dev-server url clickable

### DIFF
--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -201,7 +201,7 @@ If this is a dynamic route, consider adding it to the prefetchExcludes list:
           timeEnd(chalk.green('[\u2713] Application Bundled'))
           console.log(
             `${chalk.green('[\u2713] App serving at')} ${chalk.blue(
-              `${state.config.devServer.host}:${state.config.devServer.port}`
+              `http://${state.config.devServer.host}:${state.config.devServer.port}`
             )}`
           )
         } else {


### PR DESCRIPTION
Added `http://` in front of dev-server url which makes it clickable in terminal.

## Motivation and Context
#1302 

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
