### PR TITLE
fix: prevent undefined property warning

### DIFF
--- a/packages/react-static/bin/react-static
+++ b/packages/react-static/bin/react-static
@@ -2,10 +2,12 @@
 const path = require('path')
 //
 
-init().catch(e => {
+try {
+  init()
+} catch (e) {
   console.trace(e)
   process.exit(1)
-})
+}
 
 function init() {
   const pkg = require('../package.json')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevented undefined property warning from showing up.
<!--- Describe your changes in detail -->

## Motivation and Context
`init()` doesn't return a `Promise` and therefore using `catch()` throws the respective undefined error. 

closes #1260
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

### Before

![Screenshot from 2019-09-21 16-31-33](https://user-images.githubusercontent.com/25279263/65372398-5f5de800-dc8d-11e9-80e2-c17decc1b414.png)

### After

![Screenshot from 2019-09-21 16-31-55](https://user-images.githubusercontent.com/25279263/65372397-5ec55180-dc8d-11e9-9bbd-86e6c40c6a8e.png)


<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
