### PR TITLE
Fetch state.siteData in dev (closes #1148)

### DIFF
--- a/packages/react-static/src/commands/start.js
+++ b/packages/react-static/src/commands/start.js
@@ -1,6 +1,7 @@
 import getRoutes from '../static/getRoutes'
 import generateBrowserPlugins from '../static/generateBrowserPlugins'
 import runDevServer from '../static/webpack/runDevServer'
+import fetchSiteData from '../static/fetchSiteData'
 import getConfig from '../static/getConfig'
 import extractTemplates from '../static/extractTemplates'
 import generateTemplates from '../static/generateTemplates'
@@ -22,6 +23,7 @@ export default (async function start(state = {}) {
 
   // Use a callback (a subscription)
   getConfig(state, async state => {
+    state = await fetchSiteData(state)
     state = await createIndexPlaceholder(state)
     state = await generateBrowserPlugins(state)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixes the issue described in #1148. When using a custom `Document` in the react-static config and running `react-static start`, the `Document` props did not contain `state.siteData`.

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Update start command to `fetchSiteData`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
