### PR TITLE
Fix broken links on plugin docs

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -127,10 +127,10 @@ export default pluginOptions => ({
 
 ## What can plugins do?
 
-- [Modify your `static.config.js`](/docs/plugins/node-api.md#config-function)
-- [Transform your webpack config](/docs/plugins/node-api.md#webpack-functionfunction)
-- [Append JSX to the Head of the app](/docs/plugins/node-api.md#head-componentfunction)
-- [Customize your App's router](/docs/plugins/browser-api.md#router)
+- [Modify your `static.config.js`](/docs/plugins/node-api.md#aftergetconfig)
+- [Transform your webpack config](/docs/plugins/node-api.md#webpack)
+- [Append JSX to the Head of the app](/docs/plugins/node-api.md#headelements)
+- [Customize your App's router](/docs/plugins/browser-api.md#root)
 - and more!
 
 View the [browser API docs](/docs/plugins/browser-api.md) and the [node API docs](/docs/plugins/node-api.md) for full list of API methods that can be implemented.
@@ -141,4 +141,4 @@ Only the `plugins` directory will be transformed by react-static's babel runtime
 
 Hence, when distributing your plugin, your plugin **must be ES5 compatible**.
 
-- An example of a plugin compiled before distribution is [react-static-plugin-styled-components](https://github.com/react-static/react-static/tree/master/react-static-plugin-styled-components).
+- An example of a plugin compiled before distribution is [react-static-plugin-styled-components](/packages/react-static-plugin-styled-components).


### PR DESCRIPTION

## Description

Fix broken links for "What can plugins do" and example plugin.

## Motivation and Context

Make docs great again. Fix 404 link.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
