### PR TITLE
Updated docs about `Routes` component

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,31 +38,30 @@ The routes that will be rendered are the **routes** returned by the `getRoutes` 
 
 ### Custom `Routes` Rendering
 
-Occasionally, you may need to render the automatic `<Routes>` component in a custom way. The most common use-case is illustrated in the [animated-routes](https://github.com/react-static/react-static/tree/master/examples/animated-routes) example transitions. To do this, utilize a render prop:
+Occasionally, you may need to render the automatic `<Routes>` component in a custom way. The most common use-case is for rendering animated routes, described further in the [animated-routes](https://github.com/react-static/react-static/tree/master/examples/animated-routes) guide. To do this, utilize a `render` prop:
 
 ```javascript
-import { Root, Routes } from 'react-static'
+import React from 'react';
 
-// This is the default renderer for `<Routes>`
-const RenderRoutes =
+import {Root, Routes} from 'react-static';
 
 export default () => (
   <Root>
-    <Routes>
-      {({ getComponentForPath }) => {
-        // The pathname is used to retrieve the component for that path
-        let Comp = getComponentForPath(window.location.href)
-        // The component is rendered!
-        return <Comp />
+    <Routes
+      render={({routePath, getComponentForPath}) => {
+        // The routePath is used to retrieve the component for that path
+        const element = getComponentForPath(routePath);
+        return element;
       }}
-    </Routes>
+    />
   </Root>
-)
+);
 ```
 
-**Render Props** - These special props are sent to your rendered component or render function:
+**Render Props** - These special props are sent to your `render` function:
 
-- `getComponentForPath(pathname) => Component` - Takes a pathname and returns the component (if it exists) to render that path. Returns `false` if no component is found.
+- `getComponentForPath(pathname) => ReactElement` - Takes a pathname and returns an element (if a route exists) to render that path. Returns `false` if no route is found.
+- `routePath: String` - The path of the current route. You can pass it to `getComponentForPath`.
 
 ## `useRouteData`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,21 +41,20 @@ The routes that will be rendered are the **routes** returned by the `getRoutes` 
 Occasionally, you may need to render the automatic `<Routes>` component in a custom way. The most common use-case is for rendering animated routes, described further in the [animated-routes](https://github.com/react-static/react-static/tree/master/examples/animated-routes) guide. To do this, utilize a `render` prop:
 
 ```javascript
-import React from 'react';
-
-import {Root, Routes} from 'react-static';
+import React from 'react'
+import { Root, Routes } from 'react-static'
 
 export default () => (
   <Root>
     <Routes
-      render={({routePath, getComponentForPath}) => {
+      render={({ routePath, getComponentForPath }) => {
         // The routePath is used to retrieve the component for that path
-        const element = getComponentForPath(routePath);
-        return element;
+        const element = getComponentForPath(routePath)
+        return element
       }}
     />
   </Root>
-);
+)
 ```
 
 **Render Props** - These special props are sent to your `render` function:

--- a/docs/guides/animated-routes.md
+++ b/docs/guides/animated-routes.md
@@ -43,5 +43,4 @@ const App = () => (
 )
 
 export default App
-
 ```

--- a/docs/guides/animated-routes.md
+++ b/docs/guides/animated-routes.md
@@ -40,8 +40,8 @@ const App = () => (
       </Routes>
     </div>
   </Root>
-);
+)
 
-export default App;
+export default App
 
 ```

--- a/docs/guides/animated-routes.md
+++ b/docs/guides/animated-routes.md
@@ -6,10 +6,10 @@ Animated Routes can be achieved so many different ways. In this example, we'll s
 - Use the `Routes` component's `render` prop API to animate between routes:
 
 ```javascript
-import React from 'react';
-import {Root, Routes} from 'react-static';
-import {Link} from '@reach/router';
-import {Transition, animated} from 'react-spring/renderprops';
+import React from 'react'
+import { Root, Routes } from 'react-static'
+import { Link } from '@reach/router'
+import { Transition, animated } from 'react-spring/renderprops'
 
 const App = () => (
   <Root>
@@ -20,22 +20,22 @@ const App = () => (
     </nav>
     <div className="content">
       <Routes>
-        {({routePath, getComponentForPath}) => {
+        {({ routePath, getComponentForPath }) => {
           // Using the routePath as the key, both routes will render at the same time for the transition
           return (
             <Transition
               native
               items={routePath}
-              from={{transform: 'translateY(100px)', opacity: 0}}
-              enter={{transform: 'translateY(0px)', opacity: 1}}
-              leave={{transform: 'translateY(100px)', opacity: 0}}
+              from={{ transform: 'translateY(100px)', opacity: 0 }}
+              enter={{ transform: 'translateY(0px)', opacity: 1 }}
+              leave={{ transform: 'translateY(100px)', opacity: 0 }}
             >
-              {(item) => (props) => {
-                const element = getComponentForPath(item);
-                return <animated.div style={props}>{element}</animated.div>;
+              {item => props => {
+                const element = getComponentForPath(item)
+                return <animated.div style={props}>{element}</animated.div>
               }}
             </Transition>
-          );
+          )
         }}
       </Routes>
     </div>


### PR DESCRIPTION
## Description

Rewrote some of the docs regarding the `Routes` component, particularly to correct language and examples suggesting that you can use the children-as-function pattern with it.

## Changes/Tasks

- [x] Changed API docs
- [x] Changed `animated-routes` example

## Motivation and Context

In trying to implement this component's advanced features in my own site, I found that the docs were misleading and in some cases just wrong. The names are still somewhat confusing (why is it called `getComponentForPath` if it returns an element, not a component?) but at least the information is now correct (as far as I can tell from looking through the source).

I also updated the `animated-routes` example the best I could, but I'm not really familiar with `react-spring` and there are still some pretty big issues in the example. Namely, the temporary routes kind of stack on top of each other while transitioning, creating a janky transition, and the idea of temporarily rendering a component that isn't the current one isn't really compatible with the `useRouteData()` hook (try implementing this example in the "basic" template and navigate away from the Blogs page).

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
