### PR TITLE
Use assetsPath as Webpack publicPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fix "can not read property `catch` of `undefined`" ([#1313](https://github.com/react-static/react-static/pull/1313))
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
-- Fix `output.publicPath` in dev build when `assetPath` is set ([#1329](https://github.com/react-static/react-static/pull/1329))
+- Fix `output.publicPath` in prod build when `assetPath` is set ([#1329](https://github.com/react-static/react-static/pull/1329))
 
 ## 7.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
 
+### Fixes & Optimizations
+
+- Fix `output.publicPath` in dev build when `assetPath` is set ([#1329](https://github.com/react-static/react-static/pull/1329))
+
 ## 7.2.2
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@
 - Fix "can not read property `catch` of `undefined`" ([#1313](https://github.com/react-static/react-static/pull/1313))
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
-
-### Fixes & Optimizations
-
 - Fix `output.publicPath` in dev build when `assetPath` is set ([#1329](https://github.com/react-static/react-static/pull/1329))
 
 ## 7.2.2

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -80,7 +80,7 @@ function common(state) {
       filename: '[name].[hash:8].js', // dont use chunkhash, its not a chunk
       chunkFilename: 'templates/[name].[chunkHash:8].js',
       path: ASSETS,
-      publicPath: process.env.REACT_STATIC_PUBLIC_PATH || '/',
+      publicPath: process.env.REACT_STATIC_ASSETS_PATH || '/',
     },
     optimization: {
       sideEffects: true,


### PR DESCRIPTION
## Changes/Tasks

- [x] Changed `output.publicPath` to the `REACT_STATIC_ASSETS_PATH ` variable

## Motivation and Context

Based on what `publicPath` [does in Webpack](https://webpack.js.org/configuration/output/#outputpublicpath), I believe it's actually better set to what React-Static calls `assetsPath`. The dev Webpack configuration already works this way.

In our use case, the assets are hosted on a different CDN than the actual site - if the `siteRoot` is `https://www.example.com`, the `assetRoot` is `https://xxxxx.cloudfront.net`. However, certain imports (mostly images imported like `import imgSrc from '../img.png';`) were still resulting in a path like `https://www.example.com/static/img.png`.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly*
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them**

*This is just a bugfix, I don't think documentation changes are necessary
** Don't think there's anything to test here