### PR TITLE
Add unofficial plugin react-static-plugin-file-watch-reload to plugins list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix "can not read property `catch` of `undefined`" ([#1313](https://github.com/react-static/react-static/pull/1313))
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
+- Add unofficial plugin `react-static-plugin-file-watch-reload` to plugins list
 
 ## 7.2.2
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -38,6 +38,7 @@ React Static ships with a plugin API to extend React Static's functionality.
 - Other
 
   - [react-static-plugin-google-tag-manager](https://www.npmjs.com/package/react-static-plugin-google-tag-manager) - Easily add the GTM script tag to your HTML files
+  - [react-static-plugin-file-watch-reload](https://www.npmjs.com/package/react-static-plugin-file-watch-reload) - Allows you to specify files, that, when changed, will trigger a route reload in development
   - [react-static-plugin-yandex-metrica](https://www.npmjs.com/package/react-static-plugin-yandex-metrica) - Add the [Yandex Metrica](https://metrica.yandex.com/about) script tag
 
 ### Local Plugins via the `/plugins` directory


### PR DESCRIPTION

## Description

This adds the [`react-static-plugin-file-watch-reload`](https://github.com/wappsify/react-static-file-watch-reload) plugin to the plugin list.
I just published that plugin, it wraps `chokidar` for easy file watching in development mode.

## Checklist:

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
