### PR TITLE
Remove absolute paths from generated JS

### DIFF
--- a/packages/react-static/src/bootstrapPlugins.js
+++ b/packages/react-static/src/bootstrapPlugins.js
@@ -5,7 +5,12 @@ const { registerPlugins } = require('./browser')
 
 registerPlugins(plugins)
 
-if (typeof document !== 'undefined' && module && module.hot) {
+if (
+  process.env.NODE_ENV !== 'production' &&
+  typeof document !== 'undefined' &&
+  module &&
+  module.hot
+) {
   module.hot.accept(process.env.REACT_STATIC_PLUGINS_PATH, () => {
     registerPlugins(require(process.env.REACT_STATIC_PLUGINS_PATH).default)
   })

--- a/packages/react-static/src/bootstrapTemplates.js
+++ b/packages/react-static/src/bootstrapTemplates.js
@@ -7,7 +7,12 @@ const { default: templates, notFoundTemplate } = require(process.env
 
 registerTemplates(templates, notFoundTemplate)
 
-if (typeof document !== 'undefined' && module && module.hot) {
+if (
+  process.env.NODE_ENV !== 'production' &&
+  typeof document !== 'undefined' &&
+  module &&
+  module.hot
+) {
   module.hot.accept(process.env.REACT_STATIC_TEMPLATES_PATH, () => {
     const { default: templates, notFoundTemplate } = require(process.env
       .REACT_STATIC_TEMPLATES_PATH)

--- a/packages/react-static/src/static/__tests__/extractTemplates.test.js
+++ b/packages/react-static/src/static/__tests__/extractTemplates.test.js
@@ -46,26 +46,30 @@ test('the 404 template is the first one', async () => {
   expect(state.templates[0]).toContain('src/templates/404')
 })
 
-test('relative routes path resolves against the ROOT', async () => {
+test('relative routes path are relative and use the __react_static_root__ alias', async () => {
   const { templates } = await extractTemplates({
     config,
     routes: [{ path: '404', template: './src/templates/NotFound' }],
   })
 
-  expect(path.isAbsolute(templates[0])).toBe(true)
-  expect(path.normalize(templates[0])).toBe(
-    path.resolve(`${config.paths.ROOT}/src/templates/NotFound`)
+  expect(templates[0]).toBe(
+    `__react_static_root__/${path.relative(
+      config.paths.ROOT,
+      './src/templates/NotFound'
+    )}`
   )
 })
 
-test('absolute routes path are kept intact', async () => {
+test('absolute routes path are relative and use the __react_static_root__ alias', async () => {
   const { templates } = await extractTemplates({
     config,
     routes: [{ path: '404', template: '/home/src/templates/NotFound' }],
   })
 
-  expect(path.isAbsolute(templates[0])).toBe(true)
-  expect(path.normalize(templates[0])).toBe(
-    path.resolve('/home/src/templates/NotFound')
+  expect(templates[0]).toBe(
+    `__react_static_root__/${path.relative(
+      config.paths.ROOT,
+      '/home/src/templates/NotFound'
+    )}`
   )
 })

--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -17,7 +17,12 @@ export default (async function extractTemplates(state) {
       return
     }
 
-    route.template = slash(path.resolve(config.paths.ROOT, route.template))
+    route.template = slash(
+      `__react_static_root__/${path.relative(
+        config.paths.ROOT,
+        route.template
+      )}`
+    )
 
     // Check if the template has already been added
     const index = templates.indexOf(route.template)

--- a/packages/react-static/src/static/generateBrowserPlugins.js
+++ b/packages/react-static/src/static/generateBrowserPlugins.js
@@ -24,7 +24,12 @@ export default async state => {
           : -1
         if (pluginIndex === -1 && browserLocation) {
           pluginImports.push(
-            slash(path.resolve(config.paths.ARTIFACTS, browserLocation))
+            slash(
+              `__react_static_root__/${path.relative(
+                config.paths.ROOT,
+                browserLocation
+              )}`
+            )
           )
           pluginIndex = pluginImports.length - 1
         }
@@ -33,7 +38,9 @@ export default async state => {
 
         // IIF to return the final plugin
         return `{
-        location: "${slash(path.resolve(config.paths.ARTIFACTS, location))}",
+        location: "${slash(
+          `__react_static_root__/${path.relative(config.paths.ROOT, location)}`
+        )}",
         plugins: ${recurse(plugins || [])},
         hooks: ${
           browserLocation

--- a/packages/react-static/src/static/generateTemplates.js
+++ b/packages/react-static/src/static/generateTemplates.js
@@ -8,18 +8,12 @@ export default async state => {
     templates,
   } = state
 
-  // convert Windows-style path separators to the Unix style to ensure sure the
-  // string literal is valid and doesn't contain escaped characters
-  const reactStaticUniversalPath = process.env.REACT_STATIC_UNIVERSAL_PATH.split(
-    '\\'
-  ).join('/')
-
   const file = `
 ${
   process.env.NODE_ENV === 'production'
     ? `
 import React from 'react'
-import universal, { setHasBabelPlugin } from '${reactStaticUniversalPath}'
+import universal, { setHasBabelPlugin } from 'react-universal-component'
 
 setHasBabelPlugin()
 
@@ -57,7 +51,7 @@ export default {
 export const notFoundTemplate = ${JSON.stringify(templates[0])}
 `
     : `
-  
+
 // Template Map
 export default {
   ${templates

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -223,9 +223,6 @@ export function buildConfig(state, config = {}) {
     paths.ARTIFACTS,
     'react-static-browser-plugins.js'
   )
-  process.env.REACT_STATIC_UNIVERSAL_PATH = require.resolve(
-    'react-universal-component'
-  )
 
   const resolvePlugin = originalLocation => {
     let options = {}

--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -53,6 +53,10 @@ export default function({ config }) {
       alias: {
         react$: resolveFrom(NODE_MODULES, 'react'),
         'react-dom$': resolveFrom(NODE_MODULES, 'react-dom'),
+        'react-universal-component': resolveFrom(
+          __dirname,
+          'react-universal-component'
+        ),
         // This is here so HMR modules use the same emitter instance.
         // Likely this is only needed for locally linked dev on RS, but still...
         'webpack/hot/emitter': resolveFrom(__dirname, 'webpack/hot/emitter'),

--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -57,6 +57,7 @@ export default function({ config }) {
           __dirname,
           'react-universal-component'
         ),
+        __react_static_root__: config.paths.ROOT,
         // This is here so HMR modules use the same emitter instance.
         // Likely this is only needed for locally linked dev on RS, but still...
         'webpack/hot/emitter': resolveFrom(__dirname, 'webpack/hot/emitter'),

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -131,6 +131,7 @@ function common(state) {
           __dirname,
           'react-universal-component'
         ),
+        __react_static_root__: config.paths.ROOT,
       },
     },
     externals: [],

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -48,8 +48,8 @@ function common(state) {
   }
 
   let extrackCSSChunks = new ExtractCssChunks({
-    filename: '[name].[chunkHash:8].css',
-    chunkFilename: '[id].[chunkHash:8].css',
+    filename: '[name].[contentHash:8].css',
+    chunkFilename: '[id].[contentHash:8].css',
   })
 
   if (!config.extractCssChunks) {
@@ -62,7 +62,7 @@ function common(state) {
       },
     }
     extrackCSSChunks = new ExtractCssChunks({
-      filename: '[name].[chunkHash:8].css',
+      filename: '[name].[contentHash:8].css',
     })
   }
 
@@ -77,8 +77,8 @@ function common(state) {
           require.resolve('../../bootstrapApp'),
         ],
     output: {
-      filename: '[name].[hash:8].js', // dont use chunkhash, its not a chunk
-      chunkFilename: 'templates/[name].[chunkHash:8].js',
+      filename: '[name].[contentHash:8].js',
+      chunkFilename: 'templates/[name].[contentHash:8].js',
       path: ASSETS,
       publicPath: process.env.REACT_STATIC_PUBLIC_PATH || '/',
     },


### PR DESCRIPTION
Attempts to fix https://github.com/react-static/react-static/issues/1303.

## Description

Absolute paths are found in the exported bundles. This is surprising, can leak information about your build system, and will cause [webpack longterm caching](https://webpack.js.org/guides/caching/) to not work if you build your site in different directories over time (or on multiple servers).

(copy of https://github.com/react-static/react-static/issues/1303#issuecomment-535139590) I've tested changing both `paths.dist` and `paths.temp` to point outside of the working directory. This works fine and no absolute paths end up in the generated files, ensuring consistent hashing even when the build directory changes.

However, I can't get `yarn build` to successfully run when also changing `paths.buildArtifacts` to a directory that's outside the working directory. I've got the same issue when using the upstream `react-static@7.2.2`.

```
Exporting HTML...
  Error: Trace: { Error: Cannot find module '@reach/router'
      at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
      at Function.Module._load (internal/modules/cjs/loader.js:562:25)
      at Module.require (internal/modules/cjs/loader.js:692:17)
      at Module.call [as require] (/react-static/packages/react-static/s  rc/utils/binHelper.js:62:26)
      at require (internal/modules/cjs/helpers.js:25:18)
      [...]
```

Unclear to me if this is a local setup issue with `yarn link` or if this would also manifest in a "real-world setup".

## Changes/Tasks

- [x] Remove usage of `REACT_STATIC_UNIVERSAL_PATH` in favor of webpack alias for it

At the time this was added (7363c0b) there were no alias set for `react-universal-component` set in the Webpack config. Now that there is, this is redundant as Webpack will automatically resolve to our chosen module.

- [x] Ensure HMR code isn't found in production bundle

This was including absolute paths, which was breaking long term caching. Unclear why this isn't picked up by Terser and removed during dead-code elimination ?

- [x] Adds a `__react_static_root__` webpack alias

This ensure we do not output absolute paths for templates and browsers plugins.

- [x] Use `contenthash` over `hash` and `chunkhash`

According to Webpack documentation, `hash` is unique per build. When building on multiple machines, this hash is different on all builds. Using `contenthash` ensure we get deterministic hashes between multiple machines and between builds.
https://webpack.js.org/configuration/output/#outputfilename

Webpack also recommend using `contenthash` for long term caching.
https://webpack.js.org/guides/caching/#output-filenames

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
