### PR TITLE
Render Document meta element higher up

### DIFF
--- a/packages/react-static/src/static/components/HeadWithMeta.js
+++ b/packages/react-static/src/static/components/HeadWithMeta.js
@@ -64,6 +64,7 @@ export default async function makeHeadWithMeta(state) {
       return false
     })
 
+    const childrenMeta = childrenArray.filter(child => child.type === 'meta')
     const childrenJS = childrenArray.filter(child => child.type === 'script')
     childrenArray = childrenArray.filter(child => {
       if (
@@ -79,6 +80,9 @@ export default async function makeHeadWithMeta(state) {
       if (child.type === 'script') {
         return false
       }
+      if (child.type === 'meta') {
+        return false
+      }
       return true
     })
 
@@ -87,6 +91,7 @@ export default async function makeHeadWithMeta(state) {
         <meta name="generator" content="React Static" />
         {head.base}
         {useHelmetTitle && head.title}
+        {childrenMeta}
         {head.meta}
         {childrenJS}
         {!route.redirect &&

--- a/packages/react-static/src/static/components/__tests__/__snapshots__/HeadWithMeta.test.js.snap
+++ b/packages/react-static/src/static/components/__tests__/__snapshots__/HeadWithMeta.test.js.snap
@@ -16,6 +16,11 @@ exports[`HeadWithMeta when route has inline CSS 1`] = `
     >
       Helmet Title
     </title>
+    <meta
+      content="Helmet application"
+      key=".0"
+      name="description"
+    />
     <link
       as="script"
       href="/assets/path/main.js"
@@ -51,11 +56,6 @@ exports[`HeadWithMeta when route has inline CSS 1`] = `
         type="text/css"
       />
     </InlineStyle>
-    <meta
-      content="Helmet application"
-      key=".0"
-      name="description"
-    />
   </head>
 </Component>
 `;
@@ -70,6 +70,11 @@ exports[`HeadWithMeta when route has no helmet title 1`] = `
     <meta
       content="React Static"
       name="generator"
+    />
+    <meta
+      content="Helmet application"
+      key=".1"
+      name="description"
     />
     <link
       as="script"
@@ -110,11 +115,6 @@ exports[`HeadWithMeta when route has no helmet title 1`] = `
     >
       Document Title
     </title>
-    <meta
-      content="Helmet application"
-      key=".1"
-      name="description"
-    />
   </head>
 </Component>
 `;
@@ -135,6 +135,11 @@ exports[`HeadWithMeta when route has title as child 1`] = `
     >
       Helmet Title
     </title>
+    <meta
+      content="Helmet application"
+      key=".1"
+      name="description"
+    />
     <link
       as="script"
       href="/assets/path/main.js"
@@ -168,11 +173,6 @@ exports[`HeadWithMeta when route has title as child 1`] = `
       href="/assets/path/bootstrap.css"
       key="clientStyleSheet_bootstrap.css"
       rel="stylesheet"
-    />
-    <meta
-      content="Helmet application"
-      key=".1"
-      name="description"
     />
   </head>
 </Component>
@@ -219,6 +219,11 @@ exports[`HeadWithMeta when route is a static route 1`] = `
     >
       Helmet Title
     </title>
+    <meta
+      content="Helmet application"
+      key=".0"
+      name="description"
+    />
     <link
       as="script"
       href="/assets/path/main.js"
@@ -252,11 +257,6 @@ exports[`HeadWithMeta when route is a static route 1`] = `
       href="/assets/path/bootstrap.css"
       key="clientStyleSheet_bootstrap.css"
       rel="stylesheet"
-    />
-    <meta
-      content="Helmet application"
-      key=".0"
-      name="description"
     />
   </head>
 </Component>


### PR DESCRIPTION
## Description

This ensure that if you set a `<meta charSet="utf-8" />` (actually, any meta tag) in your [Document](https://github.com/react-static/react-static/blob/master/docs/config.md#document), it will be rendered higher up, hence be valid and observed by browsers (charset must be in the first 1024 bytes).

https://spectrum.chat/react-static/general/hello-are-there-any-known-bugs-around-unicode-in-react-static~0ae1abd4-c64e-4f2c-8e74-63bf70479528

## Changes/Tasks

- [x] Render children `meta` element above the rest

## Motivation and Context

Fix the issue described here: https://spectrum.chat/react-static/general/hello-are-there-any-known-bugs-around-unicode-in-react-static~0ae1abd4-c64e-4f2c-8e74-63bf70479528

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
