### PR TITLE
Handle basePath without trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improved
 
+- Fix `basePath` edge case ([#1344](https://github.com/react-static/react-static/pull/1344))
 - Fix typings `withSiteData` ([#1319](https://github.com/react-static/react-static/pull/1319))
 - Fix "can not read property `catch` of `undefined`" ([#1313](https://github.com/react-static/react-static/pull/1313))
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))

--- a/packages/react-static/src/browser/utils/__tests__/shared.test.js
+++ b/packages/react-static/src/browser/utils/__tests__/shared.test.js
@@ -44,8 +44,20 @@ describe('browser/utils', () => {
       expect(getRoutePath('/')).toEqual('/')
     })
 
-    it('should return / for basePath', () => {
+    it('should return / for basePath without leading / without trailing /', () => {
       expect(getRoutePath('base/path')).toEqual('/')
+    })
+
+    it('should return / for basePath without leading / with trailing /', () => {
+      expect(getRoutePath('base/path/')).toEqual('/')
+    })
+
+    it('should return / for basePath with leading / without trailing /', () => {
+      expect(getRoutePath('/base/path')).toEqual('/')
+    })
+
+    it('should return / for basePath with leading / with trailing /', () => {
+      expect(getRoutePath('/base/path/')).toEqual('/')
     })
 
     it('should strip basePath', () => {

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -81,7 +81,7 @@ export function getRoutePath(routePath) {
   // Be sure to remove the base path
   if (process.env.REACT_STATIC_BASE_PATH) {
     routePath = routePath.replace(
-      new RegExp(`^\\/?${process.env.REACT_STATIC_BASE_PATH}\\/`),
+      new RegExp(`^\\/?${process.env.REACT_STATIC_BASE_PATH}(\\/|$)`),
       ''
     )
   }


### PR DESCRIPTION
## Description

The documentation states that the `basePath` configuration can be used to host a site at a specified path, e.g. `https://mysite.com/blog`. However, the regular expression we use doesn't catch `/blog`, only `/blog/*`.

## Changes/Tasks

* Made the path `/{basePath}` resolve to `/` when determining the route path.

## Motivation and Context

Allows sites hosted at a particular path to function as expected and as described in existing documentation.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
