### PR TITLE
Pass options to css-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
 - Add unofficial plugin `react-static-plugin-file-watch-reload` to plugins list
+- Enable configuring css loader from `react-static-plugin-sass` and `react-static-plugin-less` ([#1348](https://github.com/react-static/react-static/pull/1348))
 
 ## 7.2.2
 

--- a/packages/react-static-plugin-less/README.md
+++ b/packages/react-static-plugin-less/README.md
@@ -27,6 +27,7 @@ export default {
       "react-static-plugin-less",
       {
         includePaths: ["..."] // always includes `src/`
+        cssLoaderOptions: {}, // options for the css-loader, like modules
         // other options for the less-loader
       }
     ]

--- a/packages/react-static-plugin-less/src/node.api.js
+++ b/packages/react-static-plugin-less/src/node.api.js
@@ -3,7 +3,7 @@ import autoprefixer from 'autoprefixer'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 import semver from 'semver'
 
-export default ({ includePaths = [], ...rest }) => ({
+export default ({ includePaths = [], cssLoaderOptions, ...rest }) => ({
   webpack: (config, { stage }) => {
     let loaders = []
     const lessLoaderPath = require.resolve('less-loader')
@@ -17,6 +17,7 @@ export default ({ includePaths = [], ...rest }) => ({
       options: {
         importLoaders: 1,
         sourceMap: false,
+        ...cssLoaderOptions,
       },
     }
     const postCssLoader = {

--- a/packages/react-static-plugin-less/src/node.api.js
+++ b/packages/react-static-plugin-less/src/node.api.js
@@ -3,7 +3,7 @@ import autoprefixer from 'autoprefixer'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 import semver from 'semver'
 
-export default ({ includePaths = [], cssLoaderOptions, ...rest }) => ({
+export default ({ includePaths = [], cssLoaderOptions = {}, ...rest }) => ({
   webpack: (config, { stage }) => {
     let loaders = []
     const lessLoaderPath = require.resolve('less-loader')

--- a/packages/react-static-plugin-sass/README.md
+++ b/packages/react-static-plugin-sass/README.md
@@ -27,6 +27,7 @@ export default {
       "react-static-plugin-sass",
       {
         includePaths: ["..."] // always includes `src/`
+        cssLoaderOptions: {}, // options for the css-loader, like modules
         // other options for the sass-loader
       }
     ]

--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -3,7 +3,7 @@ import autoprefixer from 'autoprefixer'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 import semver from 'semver'
 
-export default ({ includePaths = [], cssLoaderOptions, ...rest }) => ({
+export default ({ includePaths = [], cssLoaderOptions = {}, ...rest }) => ({
   webpack: (config, { stage }) => {
     let loaders = []
 

--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -3,7 +3,7 @@ import autoprefixer from 'autoprefixer'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 import semver from 'semver'
 
-export default ({ includePaths = [], ...rest }) => ({
+export default ({ includePaths = [], cssLoaderOptions, ...rest }) => ({
   webpack: (config, { stage }) => {
     let loaders = []
 
@@ -18,6 +18,7 @@ export default ({ includePaths = [], ...rest }) => ({
       options: {
         importLoaders: 1,
         sourceMap: false,
+        ...cssLoaderOptions,
       },
     }
     const postCssLoader = {

--- a/packages/react-static-plugin-stylus/src/node.api.js
+++ b/packages/react-static-plugin-stylus/src/node.api.js
@@ -3,7 +3,7 @@ import autoprefixer from 'autoprefixer'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 import semver from 'semver'
 
-export default ({ cssLoaderOptions, ...rest }) => ({
+export default ({ cssLoaderOptions = {}, ...rest }) => ({
   webpack: (config, { stage }) => {
     let loaders = []
     const stylusLoaderPath = require.resolve('stylus-loader')


### PR DESCRIPTION
Pass options from sass plugin to css-loader to enable css modules.

## Description

Add `cssLoaderOptions` property to enable configuration of css-loader.

## Changes/Tasks

- [✓] Changed code

## Motivation and Context

Enables developers the CSS modules feature by providing options to configure css-loader used inside the react-static-plugin-sass

## Types of changes

- [ - ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ - ] Bug fix (non-breaking change which fixes an issue)
- [✓] New feature (non-breaking change which adds functionality)
- [ - ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [✓] I have updated the documentation accordingly
- [✓] I have updated the CHANGELOG with a summary of my changes
- [ - ] My changes have tests around them
