### PR TITLE
Fixes #1312 - Makes sure prefixPath is set in sitemap plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
 - Add unofficial plugin `react-static-plugin-file-watch-reload` to plugins list
+- Fix empty or undefined error in sitemap plugin ([#1233](https://github.com/react-static/react-static/issues/1233) and [#1312](https://github.com/react-static/react-static/issues/1312))
 
 ## 7.2.2
 

--- a/packages/react-static-plugin-sitemap/src/buildXML.js
+++ b/packages/react-static-plugin-sitemap/src/buildXML.js
@@ -19,13 +19,14 @@ export default async function main(state, options) {
       paths: { DIST },
       disableRoutePrefixing,
       siteRoot,
+      publicPath
     },
     staging,
   } = state
 
   const prefixPath = disableRoutePrefixing
     ? siteRoot
-    : process.env.REACT_STATIC_PUBLIC_PATH
+    : publicPath
 
   const filename = staging ? 'sitemap.staging.xml' : 'sitemap.xml'
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Fixes #1233 and #1312

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`process.env.REACT_STATIC_PUBLIC_PATH` is set in build process.
The value comes from `config.publicPath` so we can simply set it in `buildXML.js`

<!--- If it fixes an open issue, please link to the issue here. -->
It will fix these issues:
#1233
#1312

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
