### PR TITLE
Fix link to animated routes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,7 +38,7 @@ The routes that will be rendered are the **routes** returned by the `getRoutes` 
 
 ### Custom `Routes` Rendering
 
-Occasionally, you may need to render the automatic `<Routes>` component in a custom way. The most common use-case is for rendering animated routes, described further in the [animated-routes](https://github.com/react-static/react-static/tree/master/examples/animated-routes) guide. To do this, utilize a `render` prop:
+Occasionally, you may need to render the automatic `<Routes>` component in a custom way. The most common use-case is for rendering animated routes, described further in the [animated-routes](https://github.com/react-static/react-static/blob/master/docs/guides/animated-routes.md) guide. To do this, utilize a `render` prop:
 
 ```javascript
 import React from 'react'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the 404 link and added the available working reference link for Animated Routes in api docs.
https://github.com/react-static/react-static/blob/master/docs/guides/animated-routes.md

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [ ] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Just a documentation quick fix.
<!--- If it fixes an open issue, please link to the issue here. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
