### PR TITLE
Progress module writes on stderr, instead of stdout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix "can not read property `catch` of `undefined`" ([#1313](https://github.com/react-static/react-static/pull/1313))
 - Fix missing state.siteData in dev ([#1148](https://github.com/react-static/react-static/pull/1148))
 - Fix empty or undefined error in sitemap plugin ([#1233](https://github.com/react-static/react-static/issues/1233) and [#1312](https://github.com/react-static/react-static/issues/1312))
+- Fix stderr pollution by progress module ([#1356](https://github.com/react-static/react-static/pull/1356))
 
 ## 7.2.2
 

--- a/packages/react-static/src/utils/progress.js
+++ b/packages/react-static/src/utils/progress.js
@@ -9,7 +9,7 @@ export default (total, label, options) => {
       label ? `${label} ` : ''
     }[:bar] :current/:total :percent :rate/s :etas `
   }
-  const stream = options.stream || process.stderr
+  const stream = options.stream || process.stdout
   if (stream.isTTY && !options.forceNonTTY) {
     options.total = total
     return new Progress(options.format, options)


### PR DESCRIPTION
Progress module writes on stderr, instead of stdout.

## Description

I changed the output from stderr to stdout.

## Motivation and Context

I use `rush` (https://rushjs.io/) to handle a monorepo.
It looks for stderr output to check if there are errors during the build step.
If there's an error, it stops the build pipeline.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
