### PR TITLE
Commented out code that will "deny all files with extension other than .html" to allow routes with dots in them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New
 
+- Allow dots in routes. ([#1365](https://github.com/react-static/react-static/pull/1365))
 - Add `silent` option ([#1330](https://github.com/react-static/react-static/pull/1330))
 - Add clickable dev-server url ([#1306](https://github.com/react-static/react-static/pull/1306))
 - Add unofficial plugin `react-static-plugin-file-watch-reload` to plugins list

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -172,18 +172,18 @@ function startPreloader() {
 
 async function reloadClientData() {
   console.log('React Static: Reloading Data...')
-  // Delete all cached data
-  ;[
-    routeInfoByPath,
-    sharedDataByHash,
-    routeErrorByPath,
-    inflightRouteInfo,
-    inflightPropHashes,
-  ].forEach(part => {
-    Object.keys(part).forEach(key => {
-      delete part[key]
+    // Delete all cached data
+    ;[
+      routeInfoByPath,
+      sharedDataByHash,
+      routeErrorByPath,
+      inflightRouteInfo,
+      inflightPropHashes,
+    ].forEach(part => {
+      Object.keys(part).forEach(key => {
+        delete part[key]
+      })
     })
-  })
 
   // Prefetch the current route's data before you reload routes
   await prefetch(window.location.pathname)
@@ -440,9 +440,9 @@ export function isPrefetchableRoute(path) {
   }
 
   // deny all files with extension other than .html
-  if (link.pathname.includes('.') && !link.pathname.includes('.html')) {
-    return false
-  }
+  //if (link.pathname.includes('.') && !link.pathname.includes('.html')) {
+  //  return false
+  //}
 
   return true
 }

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -440,6 +440,7 @@ export function isPrefetchableRoute(path) {
   }
 
   // deny all files with extension other than .html
+  // Reverting this change because of issue #1354
   //if (link.pathname.includes('.') && !link.pathname.includes('.html')) {
   //  return false
   //}


### PR DESCRIPTION
## Description

Fixes issue where a route with a dot in it doesn't work.

## Motivation and Context

Fixes https://github.com/react-static/react-static/issues/1354

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
