### PR TITLE
Use chalk.supportsColor over hard wiring color output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix empty or undefined error in sitemap plugin ([#1233](https://github.com/react-static/react-static/issues/1233) and [#1312](https://github.com/react-static/react-static/issues/1312))
 - Fix stderr pollution by progress module ([#1356](https://github.com/react-static/react-static/pull/1356))
 - Fix package.json and README for `react-static-plugin-stylus` ([#1244](https://github.com/react-static/react-static/issues/1244))
+- Fix Webpack stats output in environment that don't support color ([#1370](https://github.com/react-static/react-static/pull/1370))
 
 ## 7.2.2
 

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -441,9 +441,9 @@ export function isPrefetchableRoute(path) {
 
   // deny all files with extension other than .html
   // Reverting this change because of issue #1354
-  //if (link.pathname.includes('.') && !link.pathname.includes('.html')) {
-  //  return false
-  //}
+  // if (link.pathname.includes('.') && !link.pathname.includes('.html')) {
+  //   return false
+  // }
 
   return true
 }

--- a/packages/react-static/src/static/webpack/buildProductionBundles.js
+++ b/packages/react-static/src/static/webpack/buildProductionBundles.js
@@ -48,7 +48,7 @@ export default async function buildProductionBundles(state) {
               entrypoints: false,
               chunkOrigins: false,
               chunkModules: false,
-              colors: true,
+              colors: chalk.supportsColor,
             })
           )
           if (buildErrors) {


### PR DESCRIPTION
## Description

Wherea Webpack stats color output was hard wired to be true, this PR proposes to use `chalk.supportsColor` to automatically enabled/disabled color output.

## Motivation and Context

This ensures that in environment where color output is not supported, no "color escape code" is rendered to screen.

## Screenshots (if appropriate):

Example of output currently produced on environment that don't support colored output:

```
Version: webpack ·[1m4.33.0·[39m·[22m
Time: ·[1m80841·[39m·[22mms
Built at: 01/24/2020 ·[1m8:46:42 PM·[39m·[22m
```

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)