### PR TITLE
Add inline script hashes to DocumentProps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # never EVER use CRLF, Windows
 * text eol=lf
+# Ignore line endings in PNG files
+*.png binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add unofficial plugin `react-static-plugin-file-watch-reload` to plugins list
 - Enable configuring css loader from `react-static-plugin-sass` and `react-static-plugin-less` ([#1348](https://github.com/react-static/react-static/pull/1348))
 - Update `react-static-plugin-jss` for react-jss v10+. ([#1367](https://github.com/react-static/react-static/pull/1367))
+- Add inline script hashes to `DocumentProps`. These hashes can be used to construct a Content Security Policy in a meta tag without `unsafe-inline` scripts.
 
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add unofficial plugin `react-static-plugin-file-watch-reload` to plugins list
 - Enable configuring css loader from `react-static-plugin-sass` and `react-static-plugin-less` ([#1348](https://github.com/react-static/react-static/pull/1348))
 - Update `react-static-plugin-jss` for react-jss v10+. ([#1367](https://github.com/react-static/react-static/pull/1367))
-- Add inline script hashes to `DocumentProps`. These hashes can be used to construct a Content Security Policy in a meta tag without `unsafe-inline` scripts.
+- Add inline script hashes to `DocumentProps`. These hashes can be used to construct a Content Security Policy in a meta tag without `unsafe-inline` scripts. ([#1373](https://github.com/react-static/react-static/pull/1373))
 
 
 ### Improved

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,8 @@ We're stoked that you want to help contribute to React Static! Below are a numbe
   - `yarn build` - Builds all packages for release
   - `yarn test` - Runs the testing suite for all packages
   - `yarn startDocs` - Starts the documentation site in development mode
+* Install package from local source:
+  - Change dir to package dir, eg.: `cd packages/react-static`, then:
+  - `yarn build`
+  - `yarn link`
+  - Go to your project dir and then: `yarn link react-static`. This will use the version of `react-static` that you've just built.

--- a/docs/config.md
+++ b/docs/config.md
@@ -205,7 +205,18 @@ Props
   - `routeInfo: Object` - All of the current route's information, including any `routeData`.
   - `siteData: Object` - Any data optionally resolved via the `getSiteData` function in this config file.
   - `renderMeta: Object` - Any data optionally set via hooks or transformers during the render process.
-  - And much more!
+  - `inlineScripts: Object` - The source and hash of inline scripts added by `react-static`, eg.:
+  
+  ```json
+  { 
+      "routeInfo": { 
+          "script": "script", 
+          "hash": "sha256-<base64-value",
+      }
+  }
+  ```
+  
+  You can add the hashes as CSP directives to make the site work without `unsafe-inline`.
 
 ```javascript
 // static.config.js

--- a/docs/config.md
+++ b/docs/config.md
@@ -211,7 +211,7 @@ Props
   { 
       "routeInfo": { 
           "script": "script", 
-          "hash": "sha256-<base64-value",
+          "hash": "sha256-<base64-value>"
       }
   }
   ```

--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -584,6 +584,22 @@ export interface PathsConfig {
 
 export type DocumentComponent<T extends object = any> = React.ComponentType<DocumentProps<T>>
 
+export interface InlineScript {
+  /**
+   * The script as a string.
+   */
+  script: string
+  /**
+   * The script's sha256 hash in base64 using the subresource integrity format,
+   * eg.: 'sha256-<base64-value>'. This value can be directly used in a CSP.
+   */
+  hash: string
+}
+
+export interface InlineScripts {
+  routeInfo: InlineScript
+}
+
 export interface DocumentProps<T extends object = any> {
   Html: JSX.IntrinsicElements['html']
   Head: JSX.IntrinsicElements['head']
@@ -592,7 +608,8 @@ export interface DocumentProps<T extends object = any> {
   state: {
     siteData: T
     routeInfo: unknown
-    renderMeta: unknown
+    renderMeta: unknown,
+    inlineScripts: InlineScripts
   }
 }
 

--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -596,7 +596,7 @@ export interface InlineScript {
   hash: string
 }
 
-export interface InlineScripts {
+export interface InlineScripts extends Record<string, InlineScript> {
   routeInfo: InlineScript
 }
 

--- a/packages/react-static/src/static/__tests__/exportRoute.test.js
+++ b/packages/react-static/src/static/__tests__/exportRoute.test.js
@@ -1,0 +1,24 @@
+import { getEmbeddedRouteInfoScript } from '../exportRoute'
+
+describe('Embedded route info', () => {
+  it('should assign to window.__routeInfo', () => {
+    const res = getEmbeddedRouteInfoScript({})
+    expect(res.script.startsWith('window.__routeInfo =')).toBeTruthy()
+  })
+
+  it('should include route info', () => {
+    const info = 'my-route-info'
+    const res = getEmbeddedRouteInfoScript({routeInfo: info})
+    expect(res.script.includes(info)).toBeTruthy()
+  })
+
+  it('should include hash algorithm as prefix', () => {
+    const res = getEmbeddedRouteInfoScript({})
+    expect(res.hash.startsWith('sha256-')).toBeTruthy()
+  })
+
+  it('should include hash as base64', () => {
+    const res = getEmbeddedRouteInfoScript({})
+    atob(res.hash.substr('sha256-'.length))
+  })
+})

--- a/packages/react-static/src/static/components/BodyWithMeta.js
+++ b/packages/react-static/src/static/components/BodyWithMeta.js
@@ -1,21 +1,11 @@
 import React from 'react'
-import jsesc from 'jsesc'
 import { pathJoin, makePathAbsolute } from '../../utils'
-
-const generateRouteInformation = embeddedRouteInfo => ({
-  __html: `
-    window.__routeInfo = JSON.parse(${jsesc(JSON.stringify(embeddedRouteInfo), {
-      isScriptContext: true,
-      wrap: true,
-      json: true,
-    })});`,
-})
 
 // Not only do we pass react-helmet attributes and the app.js here, but
 // we also need to  hard code site props and route props into the page to
 // prevent flashing when react mounts onto the HTML.
 const makeBodyWithMeta = async state => {
-  const { head, route, embeddedRouteInfo, clientScripts = [] } = state
+  const { head, route, inlineScripts, clientScripts = [] } = state
 
   // This embeddedRouteInfo will be inlined into the HTML for this route.
   // It should only include the full props, not the partials.
@@ -26,7 +16,7 @@ const makeBodyWithMeta = async state => {
       {!route.redirect ? (
         <script
           type="text/javascript"
-          dangerouslySetInnerHTML={generateRouteInformation(embeddedRouteInfo)}
+          dangerouslySetInnerHTML={{ __html: inlineScripts.routeInfo.script }}
         />
       ) : null}
       {!route.redirect

--- a/packages/react-static/src/static/components/__tests__/BodyWithMeta.test.js
+++ b/packages/react-static/src/static/components/__tests__/BodyWithMeta.test.js
@@ -8,8 +8,10 @@ describe('BodyWithMeta', () => {
     const BodyWithMeta = await makeBodyWithMeta({
       head: { bodyProps: { lang: 'en' } },
       route: { redirect: false },
-      embeddedRouteInfo: {
-        routeDate: 'here',
+      inlineScripts: {
+        routeInfo: {
+          script: 'script',
+        },
       },
       clientScripts: ['main.js', 'bootstrap.js'],
       plugins: [],
@@ -28,8 +30,10 @@ describe('BodyWithMeta', () => {
     const BodyWithMeta = await makeBodyWithMeta({
       head: { bodyProps: { lang: 'en' } },
       route: { redirect: true },
-      embeddedRouteInfo: {
-        routeDate: 'here',
+      inlineScripts: {
+        routeInfo: {
+          script: 'script',
+        },
       },
       clientScripts: ['main.js', 'bootstrap.js'],
       config: {},

--- a/packages/react-static/src/static/components/__tests__/__snapshots__/BodyWithMeta.test.js.snap
+++ b/packages/react-static/src/static/components/__tests__/__snapshots__/BodyWithMeta.test.js.snap
@@ -29,8 +29,7 @@ exports[`BodyWithMeta when route is a static route 1`] = `
     <script
       dangerouslySetInnerHTML={
         Object {
-          "__html": "
-    window.__routeInfo = JSON.parse(\\"{\\\\\\"routeDate\\\\\\":\\\\\\"here\\\\\\"}\\");",
+          "__html": "script",
         }
       }
       type="text/javascript"


### PR DESCRIPTION
## Description

This PR adds a new object to the `state` attribute of `DocumentProps` called `inlineScripts`. The keys of the `inlineScripts` object are descriptive names of the scripts and contain the script source and its SHA256 hash. There is currently only one inline script, the route info hydration script:

```json
  { 
      "routeInfo": { 
          "script": "window.__routeInfo = JSON.parse(\"route data as json string\")", 
          "hash": "sha256-<base64-value>",
      }
  }
```

These hashes can be used to construct a Content Security Policy in a meta tag without needing `unsafe-inline` for scripts. 

## Changes/Tasks

- [x] Refactor `generateRouteInformation` and move it from `BodyWithMeta.js` to `exportRoute.js`, as the inline route info script hash has to be computed there.
- [x] Move testing inline route info script from `BodyWithMeta.test.js` to `exportRoute.test.js`
- [x] Update `BodyWithMeta.test.js.snap` to only check for presence of injected script, not the script's contents, since the script isn't generate in `BodyWithMeta` anymore.
- [x] Compute SHA256 hash for route info inline script in `exportRoute`.
- [x] Test script hashes in `exportRoute.test.js`
- [x] Add `inlineScripts` member to `state` in `exportRoute` that holds the script source and its hash
- [x] Add `inlineScripts` to to `DocumentProps` interface in the type def file.
- [x] Add `inlineScripts` to `Document` documentation in `docs/config.md`.

## Motivation and Context

Resolves #1362

## Types of changes

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
