### PR TITLE
Mark .sketch file as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 * text eol=lf
 # Ignore line endings in PNG files
 *.png binary
+*.sketch binary


### PR DESCRIPTION
## Description

Closes https://github.com/react-static/react-static/issues/1339.

## Changes/Tasks

- [x] Marks `.sketch` files as binary in `.gitattributes`

## Motivation and Context

Before this change, upon cloning `react-static` to my computer I would get the following, per https://github.com/react-static/react-static/pull/1373#issuecomment-582525419.

```
~/Sites/react-static master*
❯ git status
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   media/media.sketch

no changes added to commit (use "git add" and/or "git commit -a")

~/Sites/react-static master*
❯ git diff
warning: CRLF will be replaced by LF in media/media.sketch.
The file will have its original line endings in your working directory
diff --git a/media/media.sketch b/media/media.sketch
index d26a064..6b2f857 100644
Binary files a/media/media.sketch and b/media/media.sketch differ
```

This change ensure the directory is clean.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes

I don't think this deserve an entry in the change log but if you think so I'll be happy to add one, just let me know!

- [ ] My changes have tests around them