### PR TITLE
Fixed the function definition example

### DIFF
--- a/docs/plugins/node-api.md
+++ b/docs/plugins/node-api.md
@@ -283,7 +283,7 @@ An **async** function to modify the CLI state after starting the development ser
 
 export default pluginOptions => ({
   beforeRenderToElement: async (App, state) => {
-    const NewApp => props => {
+    const NewApp = props => {
       return <App {...props} />
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the function definition example for `beforeRenderToElement` in the `node.api.js` docs

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed docs

## Motivation and Context

There was error in the docs

## Screenshots (if appropriate):

<img width="889" alt="docs" src="https://user-images.githubusercontent.com/251937/74101656-82097400-4b3c-11ea-9e6b-534e91a26207.png">
