### PR TITLE
Add environment variables to change xhr polling (DevServer) host and port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Enable configuring css loader from `react-static-plugin-sass` and `react-static-plugin-less` ([#1348](https://github.com/react-static/react-static/pull/1348))
 - Update `react-static-plugin-jss` for react-jss v10+. ([#1367](https://github.com/react-static/react-static/pull/1367))
 - Add inline script hashes to `DocumentProps`. These hashes can be used to construct a Content Security Policy in a meta tag without `unsafe-inline` scripts. ([#1373](https://github.com/react-static/react-static/pull/1373))
-
+- Add environments variables (`REACT_STATIC_MESSAGE_SOCKET_PORT` and `REACT_STATIC_MESSAGE_SOCKET_HOST`) to change the xhr polling(socket.io) host and port (Only DevServer)
 
 ### Improved
 

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -114,8 +114,15 @@ function init() {
       try {
         const {
           data: { port },
-        } = await axios.get('/__react-static__/getMessagePort')
-        const socket = io(`http://localhost:${port}`)
+        } = await axios.get('/__react-static__/getMessagePort');
+
+        let host = 'http://localhost';
+
+        if(process.env.REACT_STATIC_MESSAGE_SOCKET_HOST){
+          host = process.env.REACT_STATIC_MESSAGE_SOCKET_HOST;
+        }
+
+        const socket = io(`${host}:${port}`)
         socket.on('connect', () => {
           // Do nothing
         })

--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -44,8 +44,13 @@ async function runExpressServer(state) {
   const intendedPort = Number(state.config.devServer.port)
   const port = await findAvailablePort(intendedPort)
 
+  let defaultMessagePort = 4000;
+
+  if(process.env.REACT_STATIC_MESSAGE_SOCKET_PORT){
+    defaultMessagePort = process.env.REACT_STATIC_MESSAGE_SOCKET_PORT;
+  }
   // Find an available port for messages, as long as it's not the devServer port
-  const messagePort = await findAvailablePort(4000, [port])
+  const messagePort = await findAvailablePort(defaultMessagePort, [port])
 
   if (intendedPort !== port) {
     console.log(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The default host and port is http://localhost:4000, but if we want change that we cant.

Just add 2 environments variables `REACT_STATIC_MESSAGE_SOCKET_PORT` and `REACT_STATIC_MESSAGE_SOCKET_HOST` and its fine.
 
<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [ ] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's required because today i cant change this host and port and i use react-static running on docker with a custom url and i want that xhr polling to resolve at the same base uri.

My example: 
- Run `react-static start` inside a docker container.
- Use a proxy to redirect my request `http://site.localhost:80` to my docker container network ip at port 3000 (`172.25.0.5:3000`)
- So i need the xhr polling request to resolve as `http://site.localhost:4000` because i have another proxy to redirect `http://site.localhost:4000` -> `172.25.0.3:4000` 

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
