### PR TITLE
Fix registration of 404 route info

### DIFF
--- a/packages/react-static/src/browser/components/Routes.js
+++ b/packages/react-static/src/browser/components/Routes.js
@@ -9,7 +9,9 @@ import {
   prefetch,
   plugins,
   onReloadTemplates,
+  routeErrorByPath,
 } from '..'
+import { getCurrentRoutePath } from '../utils'
 import { useStaticInfo } from '../hooks/useStaticInfo'
 import { routePathContext, useRoutePath } from '../hooks/useRoutePath'
 
@@ -74,6 +76,16 @@ const RoutesInner = ({ routePath, render: renderFn }) => {
       // In SRR and production, synchronously register the template for the
       // initial path
       registerTemplateForPath(path, template)
+
+      // For a 404 route we will register the current route as invalid
+      if (path === '404') {
+        const currentPath = getCurrentRoutePath()
+        // As long as we didn't navigate to the 404.html page directly
+        if (currentPath !== '404') {
+          routeErrorByPath[currentPath] = true
+          templateErrorByPath[currentPath] = true
+        }
+      }
     }
   })
 
@@ -88,7 +100,7 @@ const RoutesInner = ({ routePath, render: renderFn }) => {
     routePath = staticInfo.path
   } else if (!routePath) {
     // If a routePath is still not defined in the browser,
-    // use the window location as the defualt
+    // use the window location as the default
     routePath = decodeURIComponent(window.location.href)
   }
 

--- a/packages/react-static/src/browser/components/Routes.js
+++ b/packages/react-static/src/browser/components/Routes.js
@@ -11,7 +11,7 @@ import {
   onReloadTemplates,
   routeErrorByPath,
 } from '..'
-import { getCurrentRoutePath } from '../utils'
+import { getCurrentRoutePath, is404Path, PATH_404 } from '../utils'
 import { useStaticInfo } from '../hooks/useStaticInfo'
 import { routePathContext, useRoutePath } from '../hooks/useRoutePath'
 
@@ -21,12 +21,12 @@ import { routePathContext, useRoutePath } from '../hooks/useRoutePath'
  * @returns {React.ComponentType<{}> | false}
  */
 function getTemplateForPath(path) {
-  let is404 = path === '404'
+  let is404 = is404Path(path)
   let Comp = templatesByPath[path] || false
 
   if (!Comp && templateErrorByPath[path]) {
     is404 = true
-    Comp = templatesByPath['404'] || false
+    Comp = templatesByPath[PATH_404] || false
   }
 
   return { is404, Comp }
@@ -78,10 +78,10 @@ const RoutesInner = ({ routePath, render: renderFn }) => {
       registerTemplateForPath(path, template)
 
       // For a 404 route we will register the current route as invalid
-      if (path === '404') {
+      if (is404Path(path)) {
         const currentPath = getCurrentRoutePath()
         // As long as we didn't navigate to the 404.html page directly
-        if (currentPath !== '404') {
+        if (is404Path(currentPath)) {
           routeErrorByPath[currentPath] = true
           templateErrorByPath[currentPath] = true
         }
@@ -104,7 +104,7 @@ const RoutesInner = ({ routePath, render: renderFn }) => {
     routePath = decodeURIComponent(window.location.href)
   }
 
-  routePath = useRoutePath(routePath)
+    routePath = useRoutePath(routePath)
 
   // Try and get the template
   const { Comp, is404 } = getTemplateForPath(routePath)

--- a/packages/react-static/src/browser/hooks/useRouteData.js
+++ b/packages/react-static/src/browser/hooks/useRouteData.js
@@ -6,7 +6,7 @@ import {
   onReloadClientData,
 } from '..'
 import { useRoutePath } from './useRoutePath'
-import { getFullRouteData } from '../utils'
+import { getFullRouteData, PATH_404 } from '../utils'
 
 const useRouteData = () => {
   const routePath = useRoutePath()
@@ -21,7 +21,7 @@ const useRouteData = () => {
 
   const routeError = routeErrorByPath[routePath]
   const routeInfo = routeError
-    ? routeInfoByPath['404']
+    ? routeInfoByPath[PATH_404]
     : routeInfoByPath[routePath]
 
   // If there was an error reported for this path, throw an error

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -114,12 +114,12 @@ function init() {
       try {
         const {
           data: { port },
-        } = await axios.get('/__react-static__/getMessagePort');
+        } = await axios.get('/__react-static__/getMessagePort')
 
-        let host = 'http://localhost';
+        let host = 'http://localhost'
 
-        if(process.env.REACT_STATIC_MESSAGE_SOCKET_HOST){
-          host = process.env.REACT_STATIC_MESSAGE_SOCKET_HOST;
+        if (process.env.REACT_STATIC_MESSAGE_SOCKET_HOST) {
+          host = process.env.REACT_STATIC_MESSAGE_SOCKET_HOST
         }
 
         const socket = io(`${host}:${port}`)
@@ -179,18 +179,18 @@ function startPreloader() {
 
 async function reloadClientData() {
   console.log('React Static: Reloading Data...')
-    // Delete all cached data
-    ;[
-      routeInfoByPath,
-      sharedDataByHash,
-      routeErrorByPath,
-      inflightRouteInfo,
-      inflightPropHashes,
-    ].forEach(part => {
-      Object.keys(part).forEach(key => {
-        delete part[key]
-      })
+  // Delete all cached data
+  ;[
+    routeInfoByPath,
+    sharedDataByHash,
+    routeErrorByPath,
+    inflightRouteInfo,
+    inflightPropHashes,
+  ].forEach(part => {
+    Object.keys(part).forEach(key => {
+      delete part[key]
     })
+  })
 
   // Prefetch the current route's data before you reload routes
   await prefetch(window.location.pathname)

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -8,6 +8,7 @@ import {
   makePathAbsolute,
   getHooks,
   reduceHooks,
+  PATH_404,
 } from './utils'
 import onVisible from './utils/Visibility'
 
@@ -63,7 +64,7 @@ export const registerTemplates = async (tmps, notFoundKey) => {
   Object.keys(tmps).forEach(key => {
     templates[key] = tmps[key]
   })
-  templatesByPath['404'] = templates[notFoundKey]
+  templatesByPath[PATH_404] = templates[notFoundKey]
 
   if (
     process.env.NODE_ENV === 'development' &&
@@ -256,8 +257,8 @@ export async function getRouteInfo(path, { priority } = {}) {
     routeErrorByPath[path] = true
     // Unless we already fetched the 404 page,
     // try to load info for the 404 page
-    if (!routeInfoByPath['404'] && !routeErrorByPath['404']) {
-      getRouteInfo('404', { priority })
+    if (!routeInfoByPath[PATH_404] && !routeErrorByPath[PATH_404]) {
+      getRouteInfo(PATH_404, { priority })
       return
     }
 

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -233,3 +233,9 @@ export function getFullRouteData(routeInfo) {
     ...routeInfo.data,
   }
 }
+
+export const PATH_404 = '404';
+
+export function is404Path(path) {
+  return path === PATH_404;
+}

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -89,6 +89,13 @@ export function getRoutePath(routePath) {
   return pathJoin(routePath)
 }
 
+export function getCurrentRoutePath() {
+  // If in the browser, use the window
+  if (typeof document !== 'undefined') {
+    return getRoutePath(decodeURIComponent(window.location.href))
+  }
+}
+
 export function unwrapArray(arg, defaultValue) {
   arg = Array.isArray(arg) ? arg[0] : arg
   if (!arg && defaultValue) {

--- a/packages/react-static/src/static/exportRoute.js
+++ b/packages/react-static/src/static/exportRoute.js
@@ -10,7 +10,7 @@ import jsesc from 'jsesc'
 
 import Redirect from './components/Redirect'
 import plugins from './plugins'
-import { makePathAbsolute } from '../utils'
+import { makePathAbsolute, is404Path } from '../utils'
 import { absoluteToRelativeChunkName } from '../utils/chunkBuilder'
 
 import makeHtmlWithMeta from './components/HtmlWithMeta'
@@ -69,10 +69,10 @@ export default (async function exportRoute(state) {
   } = route
 
   if (incremental && remove) {
-    if (route.path === '404' || route.path === '/') {
+    if (is404Path(route.path) || route.path === '/') {
       throw new Error(
         `You are attempting to incrementally remove the ${
-          route.path === '404' ? '404' : 'index'
+          is404Path(route.path) ? '404' : 'index'
         } route from your export. This is currently not supported (or recommended) by React Static.`
       )
     }
@@ -269,10 +269,9 @@ export default (async function exportRoute(state) {
 
   // If the route is a 404 page, write it directly to 404.html, instead of
   // inside a directory.
-  const htmlFilename =
-    route.path === '404'
-      ? nodePath.join(config.paths.DIST, '404.html')
-      : nodePath.join(config.paths.DIST, route.path, 'index.html')
+  const htmlFilename = is404Path(route.path)
+    ? nodePath.join(config.paths.DIST, '404.html')
+    : nodePath.join(config.paths.DIST, route.path, 'index.html')
 
   // Make the routeInfo sit right next to its companion html file
   const routeInfoFilename = nodePath.join(

--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import slash from 'slash'
 import path from 'path'
-import { time, timeEnd } from '../utils'
+import { time, timeEnd, is404Path } from '../utils'
 
 export default (async function extractTemplates(state) {
   const { config, routes, incremental } = state
@@ -28,7 +28,7 @@ export default (async function extractTemplates(state) {
     const index = templates.indexOf(route.template)
     if (index === -1) {
       // If it's new, add it
-      if (route.path === '404') {
+      if (is404Path(route.path)) {
         // Make sure 404 template is the first one
         templates.unshift(route.template)
         notFoundPending = false

--- a/packages/react-static/src/static/getRoutes.js
+++ b/packages/react-static/src/static/getRoutes.js
@@ -1,7 +1,14 @@
 import path from 'path'
 import chalk from 'chalk'
 //
-import { pathJoin, getRoutePath, time, timeEnd } from '../utils'
+import {
+  pathJoin,
+  getRoutePath,
+  time,
+  timeEnd,
+  PATH_404,
+  is404Path,
+} from '../utils'
 import plugins from './plugins'
 
 export const rebuildRoutes = () => {
@@ -45,7 +52,7 @@ export default async function getRoutes(state, callback = d => d) {
     // If no 404 page was found, add one. This is required.
     if (!has404 && !incremental) {
       allNormalizedRoutes.unshift({
-        path: '404',
+        path: PATH_404,
         template: path.resolve(
           __dirname,
           path.join('..', 'browser', 'components', 'Default404')
@@ -117,7 +124,7 @@ export function normalizeAllRoutes(routes, state) {
       hasIndex = true
     }
 
-    if (normalizedRoute.path === '404') {
+    if (is404Path(normalizedRoute.path)) {
       has404 = true
     }
 


### PR DESCRIPTION
Make sure a 404 template is registered for the '404' path when prefetching (instead of the original path). This will prevent tv non-existing route data for a 404 page.

## Description

This was previously for V6, but apparently got lost during the refactoring of V7. See: #1014  

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
