### PR TITLE
Add conditional protocol output to serving message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update `react-static-plugin-jss` for react-jss v10+. ([#1367](https://github.com/react-static/react-static/pull/1367))
 - Add inline script hashes to `DocumentProps`. These hashes can be used to construct a Content Security Policy in a meta tag without `unsafe-inline` scripts. ([#1373](https://github.com/react-static/react-static/pull/1373))
 - Add environments variables (`REACT_STATIC_MESSAGE_SOCKET_PORT` and `REACT_STATIC_MESSAGE_SOCKET_HOST`) to change the xhr polling(socket.io) host and port (Only DevServer)
+- Update protocol shown in the "App serving at" message to display `https` when configured ([#1399](https://github.com/react-static/react-static/pull/1399))
 
 ### Improved
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -258,6 +258,20 @@ export default {
 }
 ```
 
+This can also be used to enable HTTPS support for local development:
+
+```javascript
+// static.config.js
+export default {
+  devServer: {
+    // Enable HTTPS and provide certificates
+    https: true,
+    key: fs.readFileSync('/path/to/localhost.key'),
+    cert: fs.readFileSync('/path/to/localhost.crt'),
+  },
+}
+```
+
 ### `renderToElement`
 
 **Warning:** This option has been deprecated. Please use the [Node API hook - beforeRenderToElement](https://github.com/Vinnl/react-static/tree/patch-3/docs/plugins#beforerendertoelement-function) instead.

--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -204,9 +204,10 @@ If this is a dynamic route, consider adding it to the prefetchExcludes list:
       if (isSuccessful && !skipLog) {
         if (first) {
           timeEnd(chalk.green('[\u2713] Application Bundled'))
+          const protocol = state.config.devServer.https ? 'https' : 'http'
           console.log(
             `${chalk.green('[\u2713] App serving at')} ${chalk.blue(
-              `http://${state.config.devServer.host}:${state.config.devServer.port}`
+              `${protocol}://${state.config.devServer.host}:${state.config.devServer.port}`
             )}`
           )
         } else {


### PR DESCRIPTION
## Description

This fixes the issue where https is configured but the "App serving at" URL in the console is still displayed with the http protocol.

## Changes/Tasks

- [x] Change protocol in "App serving at" message

## Motivation and Context

When developing locally one might want to run the application in https to avoid missing mixed content issues for example, or to take advantage of browser features that require HTTPS. Right now it is already possible to configure the app for https operation by using `static.config.js`:

```js
export default {
  devServer: {
    https: true,
    key: fs.readFileSync('/path/to/localhost.key'),
    cert: fs.readFileSync('/path/to/localhost.crt'),
  },
}
```

however, once this option is set, the console output remains unchanged due to the currently hard-coded `http://` prefix

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
    > Added a section on how to enable HTTPS for local development so folks don't need to look up how to configure that aspect of the Webpack Dev Server
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them