### PR TITLE
#1403 Update api docs for rebuildRoutes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -250,7 +250,9 @@ rebuildRoutes()
 
 // Reload when files change
 import chokidar from 'chokidar'
-chokidar.watch('./docs').on('all', () => rebuildRoutes())
+// Ensure routes are built at least once before rebuilding routes 
+let areRoutesBuilt = false
+chokidar.watch('./docs').on('all', () => isReady  && rebuildRoutes())
 
 // Reload from API or CMS event
 YourFavoriteCMS.subscribe(rebuildRoutes)
@@ -262,6 +264,7 @@ setInterval(rebuildRoutes, 10 * 1000)
 
 export default {
   getRoutes: () => {
+    areRoutesBuilt = true
     // This will run each time `rebuildRoutes` is called
   },
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

`rebuildRoutes` cannot be called before `getRoutes()` leading to the gotcha in issue #1403. This PR applies the recommended fix  by @SleeplessByte to the documentation. 

## Changes/Tasks
- Added `areRoutesBuilt` flag that gets set to `true` the first time `getRoutes` is run

- [x] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The documentation for `rebuildRoutes` do not account for the fact that `getRoutes()` must be called first. Relevant issue #1403. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
