### PR TITLE
Add call to fetchSiteData when reloadClientData is called in runDevserver.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix stderr pollution by progress module ([#1356](https://github.com/react-static/react-static/pull/1356))
 - Fix package.json and README for `react-static-plugin-stylus` ([#1244](https://github.com/react-static/react-static/issues/1244))
 - Fix Webpack stats output in environment that don't support color ([#1370](https://github.com/react-static/react-static/pull/1370))
+- Fix reloadClientData to call fetchSiteData runDevserver.js ([#1409](https://github.com/react-static/react-static/pull/1409))
 
 ## 7.2.2
 

--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -134,7 +134,7 @@ async function runExpressServer(state) {
                 if (!route) {
                   const err = new Error(
                     `Route could not be found for: ${routePath}
-                    
+
 If you removed this route, disregard this error.
 If this is a dynamic route, consider adding it to the prefetchExcludes list:
 
@@ -226,6 +226,7 @@ If this is a dynamic route, consider adding it to the prefetchExcludes list:
   const socket = io()
 
   reloadClientData.current = async () => {
+    await buildDevRoutes(latestState);
     socket.emit('message', { type: 'reloadClientData' })
   }
 

--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -12,9 +12,7 @@ import fetchSiteData from '../fetchSiteData'
 
 let devServer
 let latestState
-let buildSiteDataRoute = () => {}
 let buildDevRoutes = () => {}
-const getLatestState = () => latestState
 
 export const reloadClientData = () => {
   if (reloadClientData.current) {
@@ -112,9 +110,10 @@ async function runExpressServer(state) {
       // uses any up to date getData callback generated from new or replacement routes.
       buildDevRoutes = async newState => {
         latestState = await fetchSiteData(newState)
+
         app.get('/__react-static__/siteData', async (req, res, next) => {
           try {
-            res.send(getLatestState().siteData)
+            res.send(latestState.siteData)
           } catch (err) {
             res.status(500)
             res.send(err)
@@ -130,7 +129,7 @@ async function runExpressServer(state) {
             )}`,
             async (req, res, next) => {
               // Make sure we have the most up to date route from the config, not
-              // an out of dat object.
+              // an out of date object.
               let route = latestState.routes.find(d => d.path === routePath)
               try {
                 if (!route) {
@@ -229,7 +228,6 @@ If this is a dynamic route, consider adding it to the prefetchExcludes list:
 
   reloadClientData.current = async () => {
     latestState = await fetchSiteData(latestState)
-    await buildSiteDataRoute(latestState);
     socket.emit('message', { type: 'reloadClientData' })
   }
 


### PR DESCRIPTION
## Description

Fix for https://github.com/react-static/react-static/issues/1093

The suggestion in the issue above was to update the latestState variable directly, but as mentioned this doesn't work. I believe this is primarily because the routes are set already and `before` is not called when the webpack dev server is invalidated. 

Testing locally this works, just wanted a second opinion before i look into adding tests as it may be overly heavy-handed.

## Changes/Tasks

- [ ] Updated to call buildDevRoutes
- [ ] (TODO): add tests if this is agreed to be a viable solution

## Motivation and Context

comes from https://github.com/react-static/react-static/issues/1093. In summary, if you try to call `reloadClientData` in static.config.js the reload happens but the data isn't actually re-retrieved.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
