### PR TITLE
Proxy '/socket.io' to socket server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix HMR in sass plugin ([#1400](https://github.com/react-static/react-static/pull/1400))
 - Fix using dots in routes. ([#1365](https://github.com/react-static/react-static/pull/1365))
 - Fix reloadClientData to call fetchSiteData runDevserver.js ([#1409](https://github.com/react-static/react-static/pull/1409))
+- Fix WebSocket connection when running over HTTPS in Safari ([#1418](https://github.com/react-static/react-static/pull/1418))
 
 ## 7.2.2
 

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -113,17 +113,7 @@ function init() {
     const io = require('socket.io-client')
     const run = async () => {
       try {
-        const {
-          data: { port },
-        } = await axios.get('/__react-static__/getMessagePort')
-
-        let host = 'http://localhost'
-
-        if (process.env.REACT_STATIC_MESSAGE_SOCKET_HOST) {
-          host = process.env.REACT_STATIC_MESSAGE_SOCKET_HOST
-        }
-
-        const socket = io(`${host}:${port}`)
+        const socket = io()
         socket.on('connect', () => {
           // Do nothing
         })


### PR DESCRIPTION
## Description

Rework how the communication with SocketIO is done. Instead of talking directly with the SocketIO server, proxy the `/socket.io` path to the SocketIO domain.

## Changes/Tasks

- [x] Initialize the SocketIO client without options (defaults to current window location)
- [x] Proxy `/socket-io` to the SocketIO server
- [x] Remove the `__getMessagePort` endpoint in the webpack-dev-server

## Motivation and Context

Following the steps outlined in the documentation to [enable HTTPS for local development](https://github.com/react-static/react-static/blob/master/docs/config.md#devserver), Safari fails to request data from the SocketIO domain (http://localhost:4000), has it isn't served over HTTPS. Chrome has no issue with this.

Safari logs the following error in the console, originating from `polling-xhr.js`:

> Not allowed to request resource
> XMLHttpRequest cannot load http://localhost:4000/socket.io/?EIO=3&transport=polling&t=N7DEOQw due to access control checks.

I have tried to run the SocketIO server on an HTTPS server, without any luck.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
