### PR TITLE
Fix wrong image route in production build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix using dots in routes. ([#1365](https://github.com/react-static/react-static/pull/1365))
 - Fix reloadClientData to call fetchSiteData runDevServer.js ([#1409](https://github.com/react-static/react-static/pull/1409))
 - Fix WebSocket connection when running over HTTPS in Safari ([#1418](https://github.com/react-static/react-static/pull/1418))
+- Fix wrong image route in production build. ([#1425](https://github.com/react-static/react-static/pull/1425))
 
 ## 7.3.0
 

--- a/packages/react-static/src/static/webpack/rules/fileLoader.js
+++ b/packages/react-static/src/static/webpack/rules/fileLoader.js
@@ -5,6 +5,7 @@ export default function({ stage, isNode }) {
       exclude: [/\.js$/, /\.html$/, /\.json$/],
       options: {
         limit: 10000,
+        name: 'static/[name].[hash:8].[ext]',
       },
       // Don't generate extra files during node build
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In production build, images larger than 10,000 bytes generates wrong
path and it generates 404 error.

Related issue is here : #1328


![image](https://user-images.githubusercontent.com/1837913/82402532-993ef280-9a97-11ea-86e9-324f24c79039.png)


## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [ ] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
