### PR TITLE
Whitelist react-universal-component from externals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Fix WebSocket connection when running over HTTPS in Safari ([#1418](https://github.com/react-static/react-static/pull/1418))
 - Fix wrong image route in production build. ([#1425](https://github.com/react-static/react-static/pull/1425))
 
+### Bugfix
+- Fix static rendering
+
 ## 7.3.0
 
 ### New

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -176,7 +176,9 @@ export default function(state) {
       }
       callback()
     },
-    nodeExternals(),
+    nodeExternals({
+      whitelist: ['react-universal-component'],
+    }),
   ]
   result.module.rules = rules(state)
   result.plugins = [


### PR DESCRIPTION
## Description

Update the `webpack-node-externals` configuration so it bundles `react-universal-component`, in turn fixing the static export. On a fresh 7.3.0 project (using the basic template), running `yarn build` will not output anything that's within a template.

## Motivation and Context

This ensure it get's bundled and that rendering on the server works. Without doing this it seems like templates do not render during the export.

This seem to have been introduced by me, in https://github.com/nddery/react-static/commit/e040cbf6fec58c49a3a20b2ffab70a7d62713457. My understanding is that where we previously used `process.env.REACT_STATIC_UNIVERSAL_PATH`, `nodeExternals` would not see the request as a node module, and would in turn bundle it. They do mention using alises in their [whitelist](https://www.npmjs.com/package/webpack-node-externals#optionswhitelist-) documentation.

Unclear how this change will play with https://github.com/react-static/react-static/pull/1383. Another possible fix would be to revert that commit.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [X] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them

It would be great to have test around the generation of the static content, unsure how feasible that currently is, and if/how this would change with RS 8.