### PR TITLE
Ensure a non-zero exit status code when build has errors 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improved
 
+### Bugfix
+- Ensure a non-zero exit status code when build has errors ([#1451](https://github.com/react-static/react-static/pull/1451))
+
 ## 7.4.0
 
 ### New

--- a/packages/react-static/bin/react-static
+++ b/packages/react-static/bin/react-static
@@ -2,12 +2,10 @@
 const path = require('path')
 //
 
-try {
-  init()
-} catch (e) {
+init().catch(e => {
   console.trace(e)
   process.exit(1)
-}
+})
 
 function init() {
   const pkg = require('../package.json')
@@ -87,6 +85,8 @@ Examples:
   $ react-static export
 
   `)
+
+  return Promise.resolve()
 }
 
 function create(options, help) {


### PR DESCRIPTION
## Description

Ensure `init()` always return a `Promise`. This prevents the issue described in https://github.com/react-static/react-static/issues/1260.

Since `init()` returns a `Promise`, it would need to be awaited for. However, we can't `await` at the top-level, so we would have needed to wrap the `try/catch` in an `async` function for it to work, like so:

Example of awaiting:

```js
async function main() {
  try {
    await init()
  } catch(e) {
    console.trace(e)
    process.exit(1)
  }
}
main()
``` 

This just seem overly complex, so I went for the `catch` as it's nicer than wrapping the `try/catch`.

## Changes/Tasks

- [X] Changed code

- `yarn build` with an error thrown, exit status is 1.
- `yarn build` with no error thrown, exit status is 0.
- `yarn react-static` logs the usage info, exit status is 0, no error logged

I have not added tests yet, would love some, will look into it!

## Motivation and Context

Closes/Fixes https://github.com/react-static/react-static/issues/1450

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
