### PR TITLE
Updated browser support docs for IE 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### New
 
-- Updated browser support docs for IE11 support
-
 ### Improved
 
 ### Bugfix
+
 - Ensure a non-zero exit status code when build has errors ([#1451](https://github.com/react-static/react-static/pull/1451))
+- Updated browser support docs for IE11 support ([#1461](https://github.com/react-static/react-static/pull/1461))
 
 ## 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New
 
-- Updated browser support docs for IE11 support ([#1361])
+- Updated browser support docs for IE11 support
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New
 
+- Updated browser support docs for IE11 support ([#1361])
+
 ### Improved
 
 ### Bugfix

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -150,18 +150,18 @@ React-Static dually relies on lowest common browser support between React itself
 - All latest versions of modern browsers (Chrome, Firefox, Safari) are supported out of the box.
 - Internet Explorer is supported, but requires using `babel-polyfill` to work (mainly relying on the `Promise` polyfill)
 
-To extend `static.config.js` for compatibility with Internet Explorer, first install `babel-polyfill`:
-`yarn add babel-polyfill`
+To extend `static.config.js` for compatibility with Internet Explorer, first install `babel-polyfill` and `core-js`:
+`yarn add babel-polyfill core-js`
 
 Then add the following webpack object to the default export of `static.config.js` to extend the existing webpack configuration:
 
 ```javascript
-webpack: (config, { stage }) => {
-  if (stage === 'prod') {
-    config.entry = ['babel-polyfill', config.entry]
-  } else if (stage === 'dev') {
-    config.entry = ['babel-polyfill', ...config.entry]
-  }
+webpack: (config) => {
+  config.entry = [
+    'babel-polyfill',
+    'core-js/web/url',
+    ...(Array.isArray(config.entry) ? config.entry : [config.entry]),
+  ];
   return config
 },
 ```

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -428,6 +428,9 @@ export function isPrefetchableRoute(path) {
   try {
     link = new URL(path, location.href)
   } catch (e) {
+    if (typeof URL !== 'function') {
+      console.error('URL polyfill is required for this browser. https://github.com/react-static/react-static/blob/master/docs/concepts.md#browser-support');
+    }
     // Return false on invalid URLs
     return false
   }


### PR DESCRIPTION
These changes bring support for older browsers with updated polyfills

## Motivation and Context

Over releases browser support for IE 11 has stopped. This PR brings compatibility. 
Fixes issues #1361

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
