### PR TITLE
7.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bugfix
 
+## 7.4.1
+
+### Bugfix
+
 - Ensure a non-zero exit status code when build has errors ([#1451](https://github.com/react-static/react-static/pull/1451))
 - Updated browser support docs for IE11 support ([#1461](https://github.com/react-static/react-static/pull/1461))
 


### PR DESCRIPTION
## Description

Updated the changelog to reflect 7.4.1.

@SleeplessByte I have not run `yarn lerna version`, (nor `publish`), as that would try and push tag to my remote, as I understand it. This said, I also haven't updated `lerna.json` or `package.json` versions. Maybe I should run `yarn lerna version --no-push`, which would update all versions, create commits and tags, but not push them ? Seems like something that maybe should happen on master (I'm not familiar with any of this..) ?

## Changes/Tasks

- [x] Changed code

## Motivation and Context

Create a 7.4.1 release, which contains some bugs fixes:

- Ensure a non-zero exit status code when build has errors ([#1451](https://github.com/react-static/react-static/pull/1451))
- Updated browser support docs for IE11 support ([#1461](https://github.com/react-static/react-static/pull/1461))

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
