### PR TITLE
fix: expand styled-component peer dep range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfix
 
 - Remove `@types/react-hot-loader` from TypeScript template ([#1485](https://github.com/react-static/react-static/pull/1485))
+- Expand `styled-components` peer dependency version range in `react-static-plugin-styled-components` to allow newer versions of styled-components to be used ([#1473](https://github.com/react-static/react-static/pull/1473))
 
 ## 7.4.1
 

--- a/packages/react-static-plugin-styled-components/README.md
+++ b/packages/react-static-plugin-styled-components/README.md
@@ -2,12 +2,16 @@
 
 A [React-Static](https://react-static.js.org) plugin that adds CSS-in-JS/SSR support for [styled-components](https://styled-components.com)
 
+## Prerequisites
+
+- styled-components 4+ (This has been tested with `4.3.2`)
+
 ## Installation
 
 In an existing react-static site run:
 
 ```bash
-$ yarn add react-static-plugin-styled-components
+$ yarn add react-static-plugin-styled-components styled-components
 ```
 
 Then add the plugin to your `static.config.js`:

--- a/packages/react-static-plugin-styled-components/package.json
+++ b/packages/react-static-plugin-styled-components/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "react": "^16.9.0",
-    "styled-components": "^4.3.2"
+    "styled-components": ">=4"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expands version range in peer dependency of styled-components plugin
Not adding styled-components as a dependency as suggested in #1455 following recommendations from styled-components:
https://styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library
<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [ ] Changed code

## Motivation and Context

Resolves #1455 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
