### PR TITLE
Remove @types/react-hot-loader from TypeScript template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugfix
 
+- Remove `@types/react-hot-loader` from TypeScript template ([#1485](https://github.com/react-static/react-static/pull/1485))
+
 ## 7.4.1
 
 ### Bugfix

--- a/packages/react-static/templates/typescript/package.json
+++ b/packages/react-static/templates/typescript/package.json
@@ -25,7 +25,6 @@
     "@types/reach__router": "^1.2",
     "@types/react": "^16.9.1",
     "@types/react-dom": "^16.8.5",
-    "@types/react-hot-loader": "^4.1.0",
     "@types/webpack-env": "^1.14.0",
     "react-hot-loader": "^4.12.11",
     "serve": "^11.1.0",


### PR DESCRIPTION
## Description

This PR simply removes the no-longer-needed dependency on `@types/react-hot-loader`.

I wasn't sure if an update to the CHANGELOG was warranted. If it is, let me know and I'll be happy to add that.
*UPDATE:* Added summary to CHANGELOG.md

## Changes/Tasks

- [x] Remove @types/react-hot-loader from TypeScript template

## Motivation and Context

* `react-hot-loader` bundles its own types since [v4.0.0](https://github.com/gaearon/react-hot-loader/releases/tag/v4.0.0)

* When running `$ npx react-static create` with the TypeScript template (before this change), `npm` would give the following warning:
  > npm WARN deprecated @types/react-hot-loader@4.1.1: This is a stub types definition. react-hot-loader provides its own type definitions, so you do not need this installed.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
