### PR TITLE
Update preact plugin

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,5 +10,5 @@ tmp
 *.d.ts
 
 # Packages build into their root
-packages/*/node.api.js
-packages/*/browser.api.js
+packages/**/node.api.js
+packages/**/browser.api.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@
 
 ### Improved
 
+- Update preact to latest version and removed outdated compat dependency ([#1486](https://github.com/react-static/react-static/pull/1486))
+- Add prefresh to replace react hot loader when using preact plugin ([#1486](https://github.com/react-static/react-static/pull/1486))
+
+
 ### Bugfix
+
+- Fix wrong react alias for preact plugin in webpack config ([#1486](https://github.com/react-static/react-static/pull/1486))
+- Fix eslintignore not ignorning package files ([#1486](https://github.com/react-static/react-static/pull/1486))
 
 ## 7.4.1
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -250,9 +250,9 @@ rebuildRoutes()
 
 // Reload when files change
 import chokidar from 'chokidar'
-// Ensure routes are built at least once before rebuilding routes 
+// Ensure routes are built at least once before rebuilding routes
 let areRoutesBuilt = false
-chokidar.watch('./docs').on('all', () => isReady  && rebuildRoutes())
+chokidar.watch('./docs').on('all', () => isReady && rebuildRoutes())
 
 // Reload from API or CMS event
 YourFavoriteCMS.subscribe(rebuildRoutes)

--- a/packages/react-static-plugin-preact/README.md
+++ b/packages/react-static-plugin-preact/README.md
@@ -17,3 +17,27 @@ export default {
   plugins: ["react-static-plugin-preact"]
 };
 ```
+
+As final step, depending on the template you started with, you might need to remove the React Hot Reload component from `index.js`. Change:
+
+```
+  const render = Comp => {
+    renderMethod(
+      <AppContainer>
+        <Comp />
+      </AppContainer>,
+      target
+    )
+  }
+```
+
+to:
+
+```
+  const render = Comp => {
+    renderMethod(
+      <Comp />,
+      target
+    )
+  }
+```

--- a/packages/react-static-plugin-preact/README.md
+++ b/packages/react-static-plugin-preact/README.md
@@ -41,3 +41,25 @@ to:
     )
   }
 ```
+
+To preserve component state when using prefresh, it is neccesary to name the components you're exporting. Instead of
+```
+export default () => {
+  return <p>Want to refresh</p>
+}
+```
+You'll have to write your components like this:
+```
+const Refresh = () => {
+  return <p>Want to refresh</p>
+}
+
+export default Refresh;
+```
+
+or
+```
+export default function Refresh () {
+  return <p>Want to refresh</p>
+}
+```

--- a/packages/react-static-plugin-preact/package.json
+++ b/packages/react-static-plugin-preact/package.json
@@ -15,12 +15,11 @@
     "preversion": "yarn build"
   },
   "peerDependencies": {
-    "preact": "^8.5.1",
-    "preact-compat": "^3.19.0"
+    "preact": "^10.4.7"
   },
   "dependencies": {
-    "preact": "^8.5.1",
-    "preact-compat": "3.19.0"
+    "@prefresh/webpack": "^0.8.2",
+    "preact": "^10.4.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/react-static-plugin-preact/package.json
+++ b/packages/react-static-plugin-preact/package.json
@@ -18,13 +18,13 @@
     "preact": "^10.4.7"
   },
   "dependencies": {
-    "@prefresh/webpack": "^0.8.2",
     "preact": "^10.4.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
-    "@babel/preset-env": "^7.5.5"
+    "@babel/preset-env": "^7.5.5",
+    "@prefresh/webpack": "^0.9.1"
   },
   "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4"
 }

--- a/packages/react-static-plugin-preact/src/node.api.js
+++ b/packages/react-static-plugin-preact/src/node.api.js
@@ -1,12 +1,20 @@
+import PreactRefreshPlugin from '@prefresh/webpack'
+
 export default () => ({
-  webpack: (config, { stage }) => {
-    if (stage === 'prod') {
-      config.resolve.alias = {
-        ...(config.resolve.alias || {}),
-        react: 'preact-compat',
-        'react-dom': 'preact-compat',
-      }
+  webpack: config => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      react$: 'preact/compat',
+      'react-dom$': 'preact/compat',
     }
+
+    // removing react hot-loader from entries
+    // and adding prefresh to plugins
+    const newEntries = config.entry.filter(x => x !== 'react-hot-loader/patch')
+    config.entry = newEntries
+
+    config.plugins.push(new PreactRefreshPlugin())
+
     return config
   },
 })

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -429,7 +429,9 @@ export function isPrefetchableRoute(path) {
     link = new URL(path, location.href)
   } catch (e) {
     if (typeof URL !== 'function') {
-      console.error('URL polyfill is required for this browser. https://github.com/react-static/react-static/blob/master/docs/concepts.md#browser-support');
+      console.error(
+        'URL polyfill is required for this browser. https://github.com/react-static/react-static/blob/master/docs/concepts.md#browser-support'
+      )
     }
     // Return false on invalid URLs
     return false

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,23 +2515,23 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
-"@prefresh/core@^0.7.2":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-0.7.4.tgz#aa61b0049c5d7e78b29db553a465cd7df036aac3"
-  integrity sha512-Qbdjg0xH7svik4ErxMLcJUblEoi1qKt/Je3qsHqLdZjtsU4/BWW6oOtz4COAZK5KirpFS56VjBYMLzi6/ueZqQ==
+"@prefresh/core@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-0.8.1.tgz#d4f15d9e3ee9c16bf420405e2b422774e807a594"
+  integrity sha512-woho+Ja8w3pxnZwq68MnWzH9ffdidrpJsV6PDTNIsJOpsLYmfCNxqxGsxIqYw40d1yjg4h6HFGbb6Y9lhyTPNA==
 
-"@prefresh/utils@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@prefresh/utils/-/utils-0.2.1.tgz#1446082c87f1ef61b0c407f1bd0e79726fb5ab45"
-  integrity sha512-Ju7WHncqUKsaFp7yAFoNSR2jdr0bjqr8AwV06LtpFmwliPe4IDGRcBGhofg+SY9yld3FUF1JWmEoUOfCyCGRhA==
+"@prefresh/utils@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@prefresh/utils/-/utils-0.3.1.tgz#f9e1a5e1fa4bc02989980733950e60520f0f9869"
+  integrity sha512-9kLzPWN4teeiKuc+Rle3SF/hyx5lzo35X4rHr+kQXnJT+BaEb1ymDWIHGkv85xjnw8+l6I1r1H7JB4BHOMJfmg==
 
-"@prefresh/webpack@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@prefresh/webpack/-/webpack-0.8.2.tgz#e789437189aaded81eaa083455078b39c5f1922a"
-  integrity sha512-c4YsahgvnaOsSu9IW12yixiYfEKbC+DjqVPSezAhN0B5wXtoaTelEY5vmPSY3bFjcFiqnWXA1NJ49WbQ5ozAcw==
+"@prefresh/webpack@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@prefresh/webpack/-/webpack-0.9.1.tgz#b06ed30ce42ceb572e2e9e13778bd36987b5f394"
+  integrity sha512-UV9bAzu+Tp2nqvWGCgczDf7BtpIIIjbJ/JqNGSs/8/9qOOqN3kAKAA1QuNf3rrXWzj1om9L8LEYQ1XhpKdkk3g==
   dependencies:
-    "@prefresh/core" "^0.7.2"
-    "@prefresh/utils" "^0.2.1"
+    "@prefresh/core" "^0.8.1"
+    "@prefresh/utils" "^0.3.1"
 
 "@reach/router@^1.2.1":
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,6 +2515,24 @@
     universal-user-agent "^3.0.0"
     url-template "^2.0.8"
 
+"@prefresh/core@^0.7.2":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@prefresh/core/-/core-0.7.4.tgz#aa61b0049c5d7e78b29db553a465cd7df036aac3"
+  integrity sha512-Qbdjg0xH7svik4ErxMLcJUblEoi1qKt/Je3qsHqLdZjtsU4/BWW6oOtz4COAZK5KirpFS56VjBYMLzi6/ueZqQ==
+
+"@prefresh/utils@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@prefresh/utils/-/utils-0.2.1.tgz#1446082c87f1ef61b0c407f1bd0e79726fb5ab45"
+  integrity sha512-Ju7WHncqUKsaFp7yAFoNSR2jdr0bjqr8AwV06LtpFmwliPe4IDGRcBGhofg+SY9yld3FUF1JWmEoUOfCyCGRhA==
+
+"@prefresh/webpack@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@prefresh/webpack/-/webpack-0.8.2.tgz#e789437189aaded81eaa083455078b39c5f1922a"
+  integrity sha512-c4YsahgvnaOsSu9IW12yixiYfEKbC+DjqVPSezAhN0B5wXtoaTelEY5vmPSY3bFjcFiqnWXA1NJ49WbQ5ozAcw==
+  dependencies:
+    "@prefresh/core" "^0.7.2"
+    "@prefresh/utils" "^0.2.1"
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -7961,13 +7979,6 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
-immutability-helper@^2.7.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.9.1.tgz#71c423ba387e67b6c6ceba0650572f2a2a6727df"
-  integrity sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==
-  dependencies:
-    invariant "^2.2.0"
-
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -8183,7 +8194,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -11825,39 +11836,10 @@ postcss@^7.0.26:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-preact-compat@3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.19.0.tgz#a71457b6a3bf051690a4411603bc2085aa061c2f"
-  integrity sha512-f83A4hIhH8Uzhb9GbIcGk8SM19ffWlwP9mDaYwQdRnMdekZwcCA7eIAbeV4EMQaV9C0Yuy8iKgBAtyTKPZQt/Q==
-  dependencies:
-    immutability-helper "^2.7.1"
-    preact-context "^1.1.3"
-    preact-render-to-string "^3.8.2"
-    preact-transition-group "^1.1.1"
-    prop-types "^15.6.2"
-    standalone-react-addons-pure-render-mixin "^0.1.1"
-
-preact-context@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/preact-context/-/preact-context-1.1.3.tgz#26d06db0f39d8d9c890df5ada9a99a943586ec68"
-  integrity sha512-2LcpjZG6JUhBgqziVH+nJtmu9PS5KzWoFx6wX2svXw0oBHhU6e8tQZhEkKLMOAxdmj7gVzApfS/B6V+fjJ/llA==
-
-preact-render-to-string@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz#bd72964d705a57da3a9e72098acaa073dd3ceff9"
-  integrity sha512-przuZPajiurStGgxMoJP0EJeC4xj5CgHv+M7GfF3YxAdhGgEWAkhOSE0xympAFN20uMayntBZpttIZqqLl77fw==
-  dependencies:
-    pretty-format "^3.5.1"
-
-preact-transition-group@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
-  integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
-
-preact@^8.5.1:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.1.tgz#3a86cf5f3d4f6eb3349fa1f106ad59756c2af0e3"
-  integrity sha512-YVnCgcboxGrorFVIPjViqkEPOtfYVDxn5GOJuXHQZiOty+JOw7A+1xJytv/mb1O2QIIRC0SyT+kapA7Wj3jdZA==
+preact@^10.4.7:
+  version "10.4.7"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.7.tgz#5a530d34b4ba45f38234be8b1b3fe910098a165f"
+  integrity sha512-DtnnPbOm7oxW7Sxf5Co+KSIOxo7bGm0vLfJN/wGey7G2sAGKnGP5+bFyE2YIgutMISQl6xFVTsOd6l/Au88VVw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -11896,11 +11878,6 @@ pretty-format@^24.8.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
-
-pretty-format@^3.5.1:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
-  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 private@^0.1.6:
   version "0.1.8"
@@ -12380,8 +12357,8 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-"react-static@file:packages/react-static":
-  version "7.4.0"
+"react-static@file:packages/react-static-plugin-reach-router/../react-static", "react-static@file:packages/react-static-plugin-react-location/../react-static", "react-static@file:packages/react-static-plugin-react-router/../react-static", "react-static@file:packages/react-static-plugin-sitemap/../react-static", "react-static@file:packages/react-static-plugin-source-filesystem/../react-static", "react-static@file:packages/react-static-plugin-typescript/../react-static":
+  version "7.4.2"
   dependencies:
     "@babel/cli" "^7.5.5"
     "@babel/core" "^7.5.5"
@@ -13762,11 +13739,6 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
-
-standalone-react-addons-pure-render-mixin@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
-  integrity sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE=
 
 state-toggle@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## Description
The preact plugin is currently not functioning due to the alias pointing to the wrong references. See #1331

## Changes/Tasks
- Upgrade preact to latest version
- Remove preact-compat (is now included in preact core)
- Change alias to correctly reference the actual react packages
- Add prefresh to replace react-hot-reload

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
see #1331 

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them


Additional Notes: I'm not 100% sure how the dependency management works with yarn workspaces and also unsure how to test the actual code on this branch with an example project. Please let me know what I can do to pull in the plugin from this branch into a fresh react-static project.