### PR TITLE
Update README.md regarding Styled Components supported version

### DIFF
--- a/packages/react-static-plugin-styled-components/README.md
+++ b/packages/react-static-plugin-styled-components/README.md
@@ -17,3 +17,6 @@ export default {
   plugins: ["react-static-plugin-styled-components"]
 };
 ```
+
+You need to install the `styled-components` dependency yourself. 
+Plugin has been tested with styled-components 4.x.y.


### PR DESCRIPTION
I had several SSR issues when building the app with the latest `styled-components` 5.x.y installed. React Static documentation doesn't mention the version support, but looking at the Issues it's not compatible with the 5.x.y, so would be great to mention this on the documentation for people to avoid spending time on debugging. 

About the issue itself; for some reason, the CSS class names generated with `styled-components` 5.x.y installed clash with each other. This happens especially when extending components like so: 

```JS
const MyElement = styled.div`
  color: pink;
`;

const OtherElement = styled(MyElement)`
  background-color: yellow;
`;
```
