### PR TITLE
Move out Suspense to a separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Update preact to latest version and removed outdated compat dependency ([#1486](https://github.com/react-static/react-static/pull/1486))
 - Add prefresh to replace react hot loader when using preact plugin ([#1486](https://github.com/react-static/react-static/pull/1486))
+- Add an instruction how to make it work with preact 10 ([#1497](https://github.com/react-static/react-static/pull/1500))
 
 
 ### Bugfix

--- a/packages/react-static/src/Suspense.js
+++ b/packages/react-static/src/Suspense.js
@@ -1,0 +1,13 @@
+import * as React from 'react'
+
+function Suspense({ key, children, ...rest }) {
+  return typeof document !== 'undefined' ? (
+    <React.Suspense key={key} {...rest}>
+      {children}
+    </React.Suspense>
+  ) : (
+    <React.Fragment key={key}>{children}</React.Fragment>
+  )
+}
+
+export default Suspense;

--- a/packages/react-static/src/bootstrapApp.js
+++ b/packages/react-static/src/bootstrapApp.js
@@ -4,6 +4,9 @@ import { staticInfoContext } from './browser/hooks/useStaticInfo'
 import Suspense from './Suspense'
 
 // Override the suspense module to be our own
+// This is expected to break when using preact
+// In order to make it work with preact 10, use `patch-package` to remove those 2 lines
+// Reference: https://github.com/react-static/react-static/pull/1500
 React.Suspense = Suspense
 React.default.Suspense = Suspense
 

--- a/packages/react-static/src/bootstrapApp.js
+++ b/packages/react-static/src/bootstrapApp.js
@@ -1,18 +1,7 @@
 /* eslint-disable import/no-dynamic-require */
 import * as React from 'react'
 import { staticInfoContext } from './browser/hooks/useStaticInfo'
-
-const OriginalSuspense = React.Suspense
-
-function Suspense({ key, children, ...rest }) {
-  return typeof document !== 'undefined' ? (
-    <OriginalSuspense key={key} {...rest}>
-      {children}
-    </OriginalSuspense>
-  ) : (
-    <React.Fragment key={key}>{children}</React.Fragment>
-  )
-}
+import Suspense from './Suspense'
 
 // Override the suspense module to be our own
 React.Suspense = Suspense


### PR DESCRIPTION
Moved out Suspense to a separate file as it was mentioned in https://github.com/react-static/react-static/issues/1497#issuecomment-686178587.

## Description

I don't mind improve this in the future, but with this change, it is possible to `import { Suspense } from "react-static"` and use it instead of React Suspense while using `preact`.

## Changes/Tasks

The idea is to be able to avoid stubbing `React.default.Suspense` while using `react-static` with `preact`. Even though it is not fully done, thanks to this PR it would be possible to `import { Suspense } from "react-static"` and remove setting `React.default.Suspense` with something like `patch-package`(at least as a temp solution).

## Motivation and Context

Preact 10 support in `react-static`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
