### PR TITLE
Update extract-css-chunks-webpack-plugin options for hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix basepath configuration for React Router ([#1520](https://github.com/react-static/react-static/pull/1520))
 - Fix mismatched chunk names between bundle and export ([#1518](https://github.com/react-static/react-static/pull/1518))
 - Bump `git-promise` to 1.0.0, fixing a security vulnerability ([#1522](https://github.com/react-static/react-static/pull/1522))
+- Fix misconfigured HMR option for extract-css-chunks-webpack-plugin ([#1505](https://github.com/react-static/react-static/pull/1505))
 
 ## 7.4.1
 

--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -44,6 +44,7 @@ export default function({ stage, isNode }) {
       loader: ExtractCssChunks.loader,
       options: {
         hot: true,
+        hmr: true,
       },
     },
     ...cssLoader,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds `hmr` when configuring `extract-css-chunks-webpack-plugin` for hot-reloading. See #1504 for details.

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
