### PR TITLE
Fix mismatched chunk names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix eslintignore not ignorning package files ([#1486](https://github.com/react-static/react-static/pull/1486))
 - Remove `@types/react-hot-loader` from TypeScript template ([#1485](https://github.com/react-static/react-static/pull/1485))
 - Expand `styled-components` peer dependency version range in `react-static-plugin-styled-components` to allow newer versions of styled-components to be used ([#1473](https://github.com/react-static/react-static/pull/1473))
+- Fix mismatched chunk names between bundle and export ([#1518](https://github.com/react-static/react-static/pull/1518))
 
 
 ## 7.4.1

--- a/packages/react-static/src/utils/__tests__/chunkBuilder.test.js
+++ b/packages/react-static/src/utils/__tests__/chunkBuilder.test.js
@@ -53,5 +53,34 @@ describe('utils/chunkBuilder', () => {
         absoluteToRelativeChunkName('C:\\foo\\bar\\bazz\\', 'src-bar')
       ).toBe('src-bar')
     })
+    it('generates relative chunk names on absolute routes', () => {
+      expect(
+        absoluteToRelativeChunkName(
+          '/foo/bar/bazz/',
+          '/foo/bar/bazz/src/component.jsx'
+        )
+      ).toBe('src-component')
+    })
+
+    it('generates relative chunk names on absolute routes on windows', () => {
+      expect(
+        absoluteToRelativeChunkName(
+          'C:\\foo\\bar\\bazz\\',
+          'C:\\foo\\bar\\bazz\\src\\component.jsx'
+        )
+      ).toBe('src-component')
+    })
+
+    it('generates relative chunk names on relative routes', () => {
+      expect(absoluteToRelativeChunkName('/foo/bar/bazz/', 'src/bar')).toBe(
+        'src-bar'
+      )
+    })
+
+    it('generates relative chunk names on relative routes on windows', () => {
+      expect(
+        absoluteToRelativeChunkName('C:\\foo\\bar\\bazz\\', 'src\\bar')
+      ).toBe('src-bar')
+    })
   })
 })

--- a/packages/react-static/src/utils/chunkBuilder.js
+++ b/packages/react-static/src/utils/chunkBuilder.js
@@ -25,13 +25,14 @@ export const chunkNameFromFile = filename => {
 
 export const absoluteToRelativeChunkName = (ROOT, chunkName) => {
   const pathPrefix = chunkNameFromFile(ROOT)
+  chunkName = chunkNameFromFile(chunkName)
 
   // inner components can simply be added aswell
   if (!chunkName.startsWith(pathPrefix)) {
-    return chunkNameFromFile(chunkName)
+    return chunkName
   }
 
   // The templates starts with the absolute path, that's the one we want to
   // replace. It's length + 1 because otherwise it would start with a hyphen
-  return chunkNameFromFile(chunkName).substring(pathPrefix.length + 1)
+  return chunkName.substring(pathPrefix.length + 1)
 }

--- a/packages/react-static/src/utils/chunkBuilder.js
+++ b/packages/react-static/src/utils/chunkBuilder.js
@@ -28,7 +28,7 @@ export const absoluteToRelativeChunkName = (ROOT, chunkName) => {
 
   // inner components can simply be added aswell
   if (!chunkName.startsWith(pathPrefix)) {
-    return chunkName
+    return chunkNameFromFile(chunkName)
   }
 
   // The templates starts with the absolute path, that's the one we want to


### PR DESCRIPTION
# Mismatched chunk names between bundle and export

## Description
When the output directory (`config.paths.dist`) is changed to somewhere outside the working directory, there's a lot of warning messages during build.

To reproduce the problem:
```
react-static create --template basic
```

Run `yarn build` right away and it works fine.

Add to `static.config.js` a `paths.dist` property that points somewhere outside the working directory.
```
export default {
  paths: {
    dist: '/tmp/react-static'
  },
  getRoutes: ...,
  plugins: ...,
}
```

Run `yarn build` again and it gives a bunch of warnings.
```
Exporting HTML across 4 threads...
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/pages/404 in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/containers/Post in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/pages/index in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/containers/Post in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/containers/Post in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/containers/Post in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/containers/Post in Webpack chunks. Please check usage of Babel plugin.
[FLUSH CHUNKS]: Unable to find __react_static_root__/src/containers/Post in Webpack chunks. Please check usage of Babel plugin.
...
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/react-static/react-static/issues/1211 has an ongoing discussion on this.

In the bundling phase, templates are generated. And if `config.paths.dist` is different from "ROOT", the webpack chunk name for each template is [computed and assigned](https://github.com/react-static/react-static/blob/master/packages/react-static/src/static/generateTemplates.js#L36) with `chunkNameFromFile()`.

In the export phase, it's doing some pre-rendering magic with `react-universal-component` that I don't understand... But at one point it also references chunk names, and in the same case when `config.paths.dist` is different from "ROOT", it [calls](https://github.com/react-static/react-static/blob/master/packages/react-static/src/static/exportRoute.js#L150) `absoluteToRelativeChunkName()` to recompute the chunk name and truncate any prefix. There it looks asymmetric that `chunkNameFromFile()` is called when there's a prefix to truncate ([L36](https://github.com/react-static/react-static/blob/master/packages/react-static/src/utils/chunkBuilder.js#L36)) but not when there isn't ([L31](https://github.com/react-static/react-static/blob/master/packages/react-static/src/utils/chunkBuilder.js#L31)). I assume that's an unintentional omission as adding `chunkNameFromFile()` back in also fixes the problem above.