### PR TITLE
Fix basepath configuration for React Router.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix eslintignore not ignorning package files ([#1486](https://github.com/react-static/react-static/pull/1486))
 - Remove `@types/react-hot-loader` from TypeScript template ([#1485](https://github.com/react-static/react-static/pull/1485))
 - Expand `styled-components` peer dependency version range in `react-static-plugin-styled-components` to allow newer versions of styled-components to be used ([#1473](https://github.com/react-static/react-static/pull/1473))
+- Fix basepath configuration for React Router ([#1520](https://github.com/react-static/react-static/pull/1520))
 
 
 ## 7.4.1

--- a/packages/react-static-plugin-react-router/src/browser.api.js
+++ b/packages/react-static-plugin-react-router/src/browser.api.js
@@ -11,7 +11,7 @@ export default ({ RouterProps: userRouterProps = {} }) => ({
     const staticInfo = useStaticInfo()
 
     const routerProps = {
-      basepath, // Required
+      basename: basepath, // Required
     }
 
     // Test for document to detect the node stage


### PR DESCRIPTION
The [`basePath`](https://github.com/react-static/react-static/blob/master/docs/config.md#basepath) configuration in `static.config.js` doesn't work properly with [`react-static-plugin-react-router`](https://github.com/react-static/react-static/tree/master/packages/react-static-plugin-react-router). 

(`basePath` doesn't work with Reach Router either, but that's a Reach Router problem, as mentioned in https://github.com/react-static/react-static/issues/1474.)

Once you have a react-static site set up with react router plugin and `basePath` configured. It builds without a fuzz, and you can see your site at http://localhost:3000/some_basepath/. But if you click on a `/about` link expecting to go to http://localhost:3000/some_basepath/about, the page will show up properly but the browser url bar will say http://localhost:3000/about.

While the basepath configuration property in Reach Router's component is called [`basepath`](https://reach.tech/router/api/Router), for whatever reason React Router calls it [`basename`](https://reactrouter.com/web/api/BrowserRouter/basename-string). The plugin needs to have its `routerProps` reflect that.

Not sure if you want me to write more about how to reproduce the problem. It's just a lot of boilerplate to use react router plugin and `basePath`.