### PR TITLE
[docs] Update Material UI guide for MUI v4

### DIFF
--- a/docs/guides/material-ui.md
+++ b/docs/guides/material-ui.md
@@ -9,11 +9,10 @@ To use Material UI's server-side rendering (SSR) with React Static:
 ```js
 // your_app/plugins/jss-provider/node.api.js
 
-import { ServerStyleSheets } from '@material-ui/core';
+import { ServerStyleSheets } from '@material-ui/core/styles';
 
 export default () => ({
   beforeRenderToHtml: (App, { meta }) => {
-    // eslint-disable-next-line no-param-reassign
     meta.muiSheets = new ServerStyleSheets();
     return meta.muiSheets.collect(App);
   },

--- a/docs/guides/material-ui.md
+++ b/docs/guides/material-ui.md
@@ -1,27 +1,37 @@
 # Material UI
 
-To use Material-UI in React Static:
+To use Material UI's server-side rendering (SSR) with React Static:
 
-- Install Material UI and its dependencies
-- Install the [`react-static-plugin-jss`](/packages/react-static-plugin-jss) plugin and configure `react-static-plugin-jss` to use a Material UI's `createGenerateClassName` instance
-- Use Material-UI as normal
+1. Install Material UI and its dependencies
+1. Add the plugin file below and modify your config as shown
+1. Use Material UI as normal
 
-```javascript
-// static.config.js
-import { createGenerateClassName } from '@material-ui/core/styles'
+```js
+// your_app/plugins/jss-provider/node.api.js
 
-const generateClassName = createGenerateClassName()
+import { ServerStyleSheets } from '@material-ui/core';
+
+export default () => ({
+  beforeRenderToHtml: (App, { meta }) => {
+    // eslint-disable-next-line no-param-reassign
+    meta.muiSheets = new ServerStyleSheets();
+    return meta.muiSheets.collect(App);
+  },
+
+  headElements: (elements, { meta }) => [
+    ...elements,
+    meta.muiSheets.getStyleElement(),
+  ],
+});
+
+```
+
+```js
+// your_app/static.config.js
 
 export default {
-  plugins: [
-    [
-      'react-static-plugin-jss',
-      {
-        providerProps: {
-          generateClassName,
-        },
-      },
-    ],
-  ],
-}
+  plugins: ['jss-provider'],
+};
 ```
+
+Note the above is not required for your app to work; it simply enables including MUI's JSS in your static bundle. Read more [here](https://material-ui.com/guides/server-rendering/).

--- a/packages/react-static-plugin-jss/src/node.api.js
+++ b/packages/react-static-plugin-jss/src/node.api.js
@@ -2,9 +2,6 @@ import React from 'react'
 import { JssProvider, SheetsRegistry } from 'react-jss'
 
 export default ({ providerProps = {} }) => ({
-  // NOTE: This whole process could likely be extracted into a reusable
-  // react-static-plugin-jss plugin. Thoughts?
-
   beforeRenderToElement: (App, { meta }) => props => {
     // Create a sheetsRegistry instance.
     meta.jssSheetsRegistry = new SheetsRegistry()


### PR DESCRIPTION
Resolves #1179 as mentioned [here](https://github.com/react-static/react-static/issues/1179#issuecomment-751135591). The plugin was out of date and no longer worked on the latest version of MUI.

Note: This does not update the generic JSS plugin (released as a separate node module) which may or may not still work (I haven't tried it with anything other than MUI). Rather than doing the work of maintaining a separate plugin for MUI, I think the community would be better served keeping this simpler guide updated and lettings folks customize according to need.

Thanks to @Herohtar and @6pm earlier for their work debugging this.