### PR TITLE
Make getComponentForPath properly return 404 page when route is invalid and 404 page exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix mismatched chunk names between bundle and export ([#1518](https://github.com/react-static/react-static/pull/1518))
 - Bump `git-promise` to 1.0.0, fixing a security vulnerability ([#1522](https://github.com/react-static/react-static/pull/1522))
 - Fix misconfigured HMR option for extract-css-chunks-webpack-plugin ([#1505](https://github.com/react-static/react-static/pull/1505))
+- Make `getComponentForPath` properly return 404 page when route is invalid and 404 page exists ([#1557](https://github.com/react-static/react-static/pull/1557))
 
 ## 7.4.1
 

--- a/packages/react-static/src/browser/components/Routes.js
+++ b/packages/react-static/src/browser/components/Routes.js
@@ -40,7 +40,7 @@ function getTemplateForPath(path) {
  */
 function getComponentForPath(path) {
   const { Comp, is404 } = getTemplateForPath(path)
-  if (is404 || !Comp) {
+  if (is404 && !Comp) {
     return false
   }
 


### PR DESCRIPTION
I was following the [animated routes guide](https://github.com/react-static/react-static/blob/master/docs/guides/animated-routes.md), and everything seemed to be working well. Then, I accidentally navigated to a non-existent route and realized that instead of my 404 page rendering automatically as it does when I don't use the `render` prop of `Routes`, nothing at all was rendered.

I dug into the implementation of `getComponentForPath` and realized that it always returns `false` if `routePath` does not match anything, even if a 404 template exists. This is due to [this line of code](https://github.com/react-static/react-static/blob/3793552f6e9ff921cb8480768a7438e386f6194b/packages/react-static/src/browser/components/Routes.js#L43) which should contain a `&&` instead of a `||` - and thus only return false when `routePath` 404s _and_ there is no `Comp` to render. This PR makes that change.

To fix things in the meantime, you can add this line of code to your custom `render` prop of `Routes`:

```JSX
//extra import to make it work
import { templatesByPath } from 'react-static';

<Routes
    render={({ routePath, getComponentForPath }) => {
    let element = getComponentForPath(routePath);

    //explicitly get the 404 page
    if (!element) element = React.createElement(templatesByPath['404']);

    //do the custom render...
```