### PR TITLE
Update emotion-plugin to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New
 
 ### Improved
+- Update emotion plugin to support 11 version ([#1558](https://github.com/react-static/react-static/pull/1558))
 
 ### Bugfix
 

--- a/packages/react-static-plugin-emotion/package.json
+++ b/packages/react-static-plugin-emotion/package.json
@@ -23,12 +23,12 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "@emotion/core": "^10.0.15",
-    "emotion": "^10.0.14",
     "react": "^16.9.0"
   },
   "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4",
   "dependencies": {
-    "emotion-server": "^10.0.14"
+    "@emotion/server": "^11.0.0",
+    "@emotion/react": "^11.1.4",
+    "@emotion/cache": "^11.1.3"
   }
 }

--- a/packages/react-static-plugin-emotion/src/browser.api.js
+++ b/packages/react-static-plugin-emotion/src/browser.api.js
@@ -1,11 +1,17 @@
-import { sheet } from 'emotion'
+import React from 'react';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
 
-// For now, speedy must be disabled for hydration to work correctly with react-statics
-if (
-  typeof document !== 'undefined' &&
-  !document.getElementById('root').hasChildNodes()
-) {
-  sheet.speedy(false)
-}
+const cache = createCache({
+  key: 'react-static-styles',
+  speedy: false
+});
 
-export default () => ({})
+
+export default () => ({
+  beforeRenderToElement: (App) => (props) => (
+    <CacheProvider value={cache}>
+      <App {...props} />
+    </CacheProvider>
+  ),
+});

--- a/packages/react-static-plugin-emotion/src/node.api.js
+++ b/packages/react-static-plugin-emotion/src/node.api.js
@@ -1,10 +1,16 @@
-import React from 'react'
-import { renderStylesToString } from 'emotion-server'
-import { cache } from 'emotion'
-import { CacheProvider } from '@emotion/core'
+import React from 'react';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
+import createEmotionServer from '@emotion/server/create-instance';
+
+const cache = createCache({
+  key: 'react-static-styles',
+});
+
+const { renderStylesToString } = createEmotionServer(cache);
 
 export default () => ({
-  beforeRenderToElement: App => props => (
+  beforeRenderToElement: (App) => (props) => (
     <CacheProvider value={cache}>
       <App {...props} />
     </CacheProvider>
@@ -13,4 +19,4 @@ export default () => ({
   // to critically inline the styles from the original
   // html into the a new html string
   beforeHtmlToDocument: renderStylesToString,
-})
+});


### PR DESCRIPTION
## Description
Updating plugin and dependencies of emotion

## Motivation and Context
Current plugin doesn't build with emotion 11

## Types of changes

- [ ] Breaking change: Emotion 10 is not supported after that.
