### PR TITLE
Move react to peerDependency for more lenient version control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Add an instruction how to make it work with preact 10 ([#1497](https://github.com/react-static/react-static/pull/1500))
 - Add ability to parse frontmatter in MDX plugin ([#1533](https://github.com/react-static/react-static/pull/1533))
 - Add ability to configure hreflang links to Sitemap ([#1539](https://github.com/react-static/react-static/1539))
-
+- Move react to peerDependencies ([#1560](https://github.com/react-static/react-static/pull/1560))
+- Add preliminary support for React 17 ([#1560](https://github.com/react-static/react-static/pull/1560))
 ### Bugfix
 
 - Fix wrong react alias for preact plugin in webpack config ([#1486](https://github.com/react-static/react-static/pull/1486))

--- a/packages/react-static-plugin-emotion/package.json
+++ b/packages/react-static-plugin-emotion/package.json
@@ -17,7 +17,7 @@
   "peerDependencies": {
     "@emotion/core": "^10.0.15",
     "emotion": "^10.0.14",
-    "react": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/react-static-plugin-evergreen/package.json
+++ b/packages/react-static-plugin-evergreen/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "evergreen-ui": "^4.18.1",
-    "react": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/packages/react-static-plugin-jss/package.json
+++ b/packages/react-static-plugin-jss/package.json
@@ -15,7 +15,7 @@
     "preversion": "yarn build"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.9.0 || ^17.0.0",
     "react-jss": "^10.0.3"
   },
   "devDependencies": {

--- a/packages/react-static-plugin-reach-router/package.json
+++ b/packages/react-static-plugin-reach-router/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "@reach/router": "^1.2.1",
-    "react": "^16.9.0",
+    "react": "^16.9.0 || ^17.0.0",
     "react-static": "^7.1.0"
   },
   "devDependencies": {

--- a/packages/react-static-plugin-react-location/package.json
+++ b/packages/react-static-plugin-react-location/package.json
@@ -15,7 +15,7 @@
     "preversion": "yarn build"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.9.0 || ^17.0.0",
     "react-location": "^2.0.5",
     "react-static": "^7.1.0"
   },

--- a/packages/react-static-plugin-react-router/package.json
+++ b/packages/react-static-plugin-react-router/package.json
@@ -15,7 +15,7 @@
     "preversion": "yarn build"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.9.0 || ^17.0.0",
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",
     "react-static": "^7.1.0"

--- a/packages/react-static-plugin-styled-components/package.json
+++ b/packages/react-static-plugin-styled-components/package.json
@@ -15,7 +15,7 @@
     "preversion": "yarn build"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.9.0 || ^17.0.0",
     "styled-components": ">=4"
   },
   "devDependencies": {

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -27,6 +27,8 @@
     "publishLink": "echo '{{event}} to {{changed}}' && yalc publish"
   },
   "peerDependencies": {
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
     "react-hot-loader": "^4.12.11"
   },
   "dependencies": {
@@ -82,10 +84,7 @@
     "prop-types": "^15.7.2",
     "raf": "^3.4.1",
     "raw-loader": "^3.1.0",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
     "react-helmet": "^5.2.1",
-    "react-hot-loader": "^4.12.11",
     "react-universal-component": "^4.0.0",
     "resolve-from": "^5.0.0",
     "serve": "^11.1.0",
@@ -127,7 +126,9 @@
     "lerna": "^3.16.4",
     "onchange": "^6.0.0",
     "prettier": "1.18.2",
+    "react": "^16.9.0",
     "react-dev-utils": "^9.0.3",
+    "react-dom": "^16.9.0",
     "react-hot-loader": "^4.12.11",
     "rimraf": "^2.7.0",
     "webpack-hot-middleware": "^2.25.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12393,10 +12393,7 @@ react-side-effect@^1.1.0:
     prop-types "^15.7.2"
     raf "^3.4.1"
     raw-loader "^3.1.0"
-    react "^16.9.0"
-    react-dom "^16.9.0"
     react-helmet "^5.2.1"
-    react-hot-loader "^4.12.11"
     react-universal-component "^4.0.0"
     resolve-from "^5.0.0"
     serve "^11.1.0"
@@ -12450,6 +12447,15 @@ react-universal-component@^4.0.0:
   dependencies:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.7.2"
+
+react@16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 react@^16.9.0:
   version "16.14.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

React doesn't need to be a `dependency` of any of the `react-static`
packages, but a `peerDependency` instead. This allows users of the
library to upgrade React versions without waiting for `react-static` to
upgrade its version.

Also removes `react-hot-loader` from `dependencies` as it was already
declared a `peerDependency`.

Add support for React 17

<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Move react and react-dom to peerDependencies
- [x] Add react as devDependency for tests to pass
- [x] remove react-hot-loader from dependencies

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It allows users of the library to more freely upgrade their React
version

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them