### PR TITLE
Upgrade postcss-loader to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Add ability to configure hreflang links to Sitemap ([#1539](https://github.com/react-static/react-static/1539))
 - Move react to peerDependencies ([#1560](https://github.com/react-static/react-static/pull/1560))
 - Add preliminary support for React 17 ([#1560](https://github.com/react-static/react-static/pull/1560))
+- Upgrade postcss-loader to 4.2.0 with new API for PostCSS 8+ plugin support ([#1563](https://github.com/react-static/react-static/pull/1563))
+- Add postcss to peerDependencies ([#1563](https://github.com/react-static/react-static/pull/1563))
+
 ### Bugfix
 
 - Fix wrong react alias for preact plugin in webpack config ([#1486](https://github.com/react-static/react-static/pull/1486))

--- a/packages/react-static-plugin-less/src/node.api.js
+++ b/packages/react-static-plugin-less/src/node.api.js
@@ -26,13 +26,14 @@ export default ({ includePaths = [], cssLoaderOptions = {}, ...rest }) => ({
         // Necessary for external CSS imports to work
         // https://github.com/facebookincubator/create-react-app/issues/2677
         sourceMap: true,
-        ident: 'postcss',
-        plugins: () => [
-          postcssFlexbugsFixes,
-          autoprefixer({
-            flexbox: 'no-2009',
-          }),
-        ],
+        postcssOptions: {
+          plugins: [
+            postcssFlexbugsFixes,
+            autoprefixer({
+              flexbox: 'no-2009',
+            }),
+          ],
+        },
       },
     }
 

--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -25,13 +25,14 @@ export default ({ includePaths = [], cssLoaderOptions = {}, ...rest }) => ({
       loader: 'postcss-loader',
       options: {
         sourceMap: true,
-        ident: 'postcss',
-        plugins: () => [
-          postcssFlexbugsFixes,
-          autoprefixer({
-            flexbox: 'no-2009',
-          }),
-        ],
+        postcssOptions: {
+          plugins: [
+            postcssFlexbugsFixes,
+            autoprefixer({
+              flexbox: 'no-2009',
+            }),
+          ],
+        },
       },
     }
 

--- a/packages/react-static-plugin-stylus/src/node.api.js
+++ b/packages/react-static-plugin-stylus/src/node.api.js
@@ -30,13 +30,14 @@ export default ({ cssLoaderOptions = {}, ...rest }) => ({
         // Necessary for external CSS imports to work
         // https://github.com/facebookincubator/create-react-app/issues/2677
         sourceMap: true,
-        ident: 'postcss',
-        plugins: () => [
-          postcssFlexbugsFixes,
-          autoprefixer({
-            flexbox: 'no-2009',
-          }),
-        ],
+        postcssOptions: {
+          plugins: [
+            postcssFlexbugsFixes,
+            autoprefixer({
+              flexbox: 'no-2009',
+            }),
+          ],
+        },
       },
     }
 

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -78,7 +78,7 @@
     "mutation-observer": "^1.0.3",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "portfinder": "^1.0.21",
-    "postcss-flexbugs-fixes": "^5.1.0",
+    "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^4.2.0",
     "pretty-error": "^2.1.1",
     "progress": "^2.0.3",

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -27,6 +27,7 @@
     "publishLink": "echo '{{event}} to {{changed}}' && yalc publish"
   },
   "peerDependencies": {
+    "postcss": "^8.2.4",
     "react-hot-loader": "^4.12.11"
   },
   "dependencies": {
@@ -75,8 +76,8 @@
     "mutation-observer": "^1.0.3",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "portfinder": "^1.0.21",
-    "postcss-flexbugs-fixes": "^4.1.0",
-    "postcss-loader": "^3.0.0",
+    "postcss-flexbugs-fixes": "^5.1.0",
+    "postcss-loader": "^4.2.0",
     "pretty-error": "^2.1.1",
     "progress": "^2.0.3",
     "prop-types": "^15.7.2",

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -27,7 +27,7 @@
     "publishLink": "echo '{{event}} to {{changed}}' && yalc publish"
   },
   "peerDependencies": {
-    "postcss": "^8.2.4",
+    "postcss": ">= 7.0.0, < 9.0.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-hot-loader": "^4.12.11"

--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -17,13 +17,14 @@ function initCSSLoader() {
         // Necessary for external CSS imports to work
         // https://github.com/facebookincubator/create-react-app/issues/2677
         sourceMap: true,
-        ident: 'postcss',
-        plugins: () => [
-          postcssFlexbugsFixes,
-          autoprefixer({
-            flexbox: 'no-2009', // I'd opt in for this - safari 9 & IE 10.
-          }),
-        ],
+        postcssOptions: {
+          plugins: [
+            postcssFlexbugsFixes,
+            autoprefixer({
+              flexbox: 'no-2009', // I'd opt in for this - safari 9 & IE 10.
+            }),
+          ],
+        },
       },
     },
   ]

--- a/packages/react-static/src/utils/binHelper.js
+++ b/packages/react-static/src/utils/binHelper.js
@@ -116,15 +116,15 @@ ignoredExtensions.forEach(ext => {
 
 const originalConsoleError = console.error
 console.error = (...args) => {
-  if(args.length === 0){
+  if (args.length === 0) {
     return undefined
   }
   const [err, ...rest] = args
-  if(err instanceof Error){
+  if (err instanceof Error) {
     console.log(new PrettyError().render(err), ...rest)
     return
   }
-  
+
   return originalConsoleError(err, ...rest)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2367,6 +2367,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/json-schema@^7.0.6":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -2755,7 +2760,7 @@ ajv@6.5.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.9.1:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -7912,13 +7917,6 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
-import-cwd@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
-  integrity sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=
-  dependencies:
-    import-from "^2.1.0"
-
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -7934,13 +7932,6 @@ import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
-
-import-from@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
-  integrity sha1-M1238qev/VOqpHHUuAId7ja387E=
-  dependencies:
-    resolve-from "^3.0.0"
 
 import-local@^2.0.0:
   version "2.0.0"
@@ -9414,6 +9405,11 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+klona@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
+  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -11526,23 +11522,16 @@ postcss-flexbugs-fixes@^4.1.0:
   dependencies:
     postcss "^7.0.26"
 
-postcss-load-config@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-2.1.2.tgz#c5ea504f2c4aef33c7359a34de3573772ad7502a"
-  integrity sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==
+postcss-loader@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.2.0.tgz#f6993ea3e0f46600fb3ee49bbd010448123a7db4"
+  integrity sha512-mqgScxHqbiz1yxbnNcPdKYo/6aVt+XExURmEbQlviFVWogDbM4AJ0A/B+ZBpYsJrTRxKw7HyRazg9x0Q9SWwLA==
   dependencies:
-    cosmiconfig "^5.0.0"
-    import-cwd "^2.0.0"
-
-postcss-loader@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-3.0.0.tgz#6b97943e47c72d845fa9e03f273773d4e8dd6c2d"
-  integrity sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==
-  dependencies:
-    loader-utils "^1.1.0"
-    postcss "^7.0.0"
-    postcss-load-config "^2.0.0"
-    schema-utils "^1.0.0"
+    cosmiconfig "^7.0.0"
+    klona "^2.0.4"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+    semver "^7.3.4"
 
 postcss-merge-longhand@^4.0.11:
   version "4.0.11"
@@ -12387,7 +12376,7 @@ react-side-effect@^1.1.0:
     optimize-css-assets-webpack-plugin "^5.0.3"
     portfinder "^1.0.21"
     postcss-flexbugs-fixes "^4.1.0"
-    postcss-loader "^3.0.0"
+    postcss-loader "^4.2.0"
     pretty-error "^2.1.1"
     progress "^2.0.3"
     prop-types "^15.7.2"
@@ -13165,6 +13154,15 @@ schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.5, schema-utils@^2.7
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
+schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -13229,6 +13227,13 @@ semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12435,15 +12435,6 @@ react-universal-component@^4.0.0:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.7.2"
 
-react@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
 react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hi there! :wave: 

PostCSS 8.0 has been released for awhile and with it came some [breaking changes for plugin APIs](https://evilmartians.com/chronicles/postcss-8-plugin-migration) - it maintains backwards compatibility with older API as far as I can tell.

However the new plugin API wasn't supported in [postcss-loader until 4.0+](https://github.com/webpack-contrib/postcss-loader/blob/master/CHANGELOG.md#403-2020-10-02) but we're locked at 3.0, effectively limiting use of plugins that require the PostCSS 8.0 API

This PR upgrades the postcss-loader, fixes the breaking loader configuration, and adds PostCSS as a peerDependency.

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Upgrade the postcss-loader and core rule
- [x] Update plugins that used the loader
- [x] `yarn build` core + plugins successfully
- [x] Test local production build with `yarn link`ed changes

## Motivation and Context

My project uses TailwindCSS which ([as of 2.0](https://tailwindcss.com/docs/upgrading-to-v2#install-tailwind-css-v2-0-and-post-css-8)) utilizes the new PostCSS 8 plugin API so I need to upgrade this dependency upstream but we're locked at 3.0 hence the PR.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
