### PR TITLE
REACT_STATIC_ASSETS_PATH as webpack.output.publicPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Improved
 
 ### Bugfix
-- Make sure assetsPath is used for webpack build and template generation
 
 ## 7.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Improved
 
 ### Bugfix
-Fix publicPath is used for webpack output publicPath instead of assetsPath
+Fix publicPath is used for webpack output publicPath instead of assetsPath ([#1569](https://github.com/react-static/react-static/pull/1569))
 
 ## 7.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improved
 
 ### Bugfix
+Fix publicPath is used for webpack output publicPath instead of assetsPath
 
 ## 7.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improved
 
 ### Bugfix
+- Make sure assetsPath is used for webpack build and template generation
 
 ## 7.5.0
 

--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -11,7 +11,7 @@ export default function({ config }) {
   const { DIST, NODE_MODULES, SRC, HTML_TEMPLATE } = config.paths
 
   process.env.REACT_STATIC_BASE_PATH = config.basePath
-  process.env.REACT_STATIC_PUBLIC_PATH = config.publicPath
+  process.env.REACT_STATIC_PUBLIC_PATH = config.assetsPath
   process.env.REACT_STATIC_ASSETS_PATH = config.assetsPath
 
   return {

--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -11,7 +11,7 @@ export default function({ config }) {
   const { DIST, NODE_MODULES, SRC, HTML_TEMPLATE } = config.paths
 
   process.env.REACT_STATIC_BASE_PATH = config.basePath
-  process.env.REACT_STATIC_PUBLIC_PATH = config.assetsPath
+  process.env.REACT_STATIC_PUBLIC_PATH = config.publicPath
   process.env.REACT_STATIC_ASSETS_PATH = config.assetsPath
 
   return {

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -80,7 +80,7 @@ function common(state) {
       filename: '[name].[contentHash:8].js',
       chunkFilename: 'templates/[name].[contentHash:8].js',
       path: ASSETS,
-      publicPath: process.env.REACT_STATIC_PUBLIC_PATH || '/',
+      publicPath: process.env.REACT_STATIC_ASSETS_PATH || '/',
     },
     optimization: {
       sideEffects: true,

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -17,7 +17,7 @@ function common(state) {
   process.env.REACT_STATIC_ENTRY_PATH = config.entry
   process.env.REACT_STATIC_SITE_ROOT = config.siteRoot
   process.env.REACT_STATIC_BASE_PATH = config.basePath
-  process.env.REACT_STATIC_PUBLIC_PATH = config.publicPath
+  process.env.REACT_STATIC_PUBLIC_PATH = config.assetsPath
   process.env.REACT_STATIC_ASSETS_PATH = config.assetsPath
 
   if (!DIST.startsWith(ROOT)) {

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -17,7 +17,7 @@ function common(state) {
   process.env.REACT_STATIC_ENTRY_PATH = config.entry
   process.env.REACT_STATIC_SITE_ROOT = config.siteRoot
   process.env.REACT_STATIC_BASE_PATH = config.basePath
-  process.env.REACT_STATIC_PUBLIC_PATH = config.assetsPath
+  process.env.REACT_STATIC_PUBLIC_PATH = config.publicPath
   process.env.REACT_STATIC_ASSETS_PATH = config.assetsPath
 
   if (!DIST.startsWith(ROOT)) {


### PR DESCRIPTION
## Description

webpack.output.publicPath for production deployment should use assetsPath value

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
