### PR TITLE
Allow plugins to modify routeInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Bugfix
 
+## 7.5.2
+
+### Improved
+
+- Add routeInfo hook ([#1572](https://github.com/react-static/react-static/pull/1572))
+
+### Bugfix
+
 ## 7.5.0
 
 ### Improved

--- a/docs/plugins/node-api.md
+++ b/docs/plugins/node-api.md
@@ -269,6 +269,33 @@ export default pluginOptions => ({
 })
 ```
 
+## `routeInfo`
+
+An **async** function to modify the routeInfo after it has been generated.
+
+- Arguments:
+  - `routeInfo` - The routeInfo
+  - `state` - The current state of the CLI
+- Returns a new routeInfo object
+
+```javascript
+// node.api.js
+
+export default pluginOptions => ({
+  routeInfo: async (routeInfo, state) => {
+    routeInfo = {
+        ...routeInfo,
+        data: {
+            ...routeInfo.data,
+            somethingElse: 'Data added in hook',
+        },
+    }
+
+    return routeInfo
+  },
+})
+```
+
 ## `beforeRenderToElement`
 
 An **async** function to modify the CLI state after starting the development server.

--- a/packages/react-static/src/static/exportRoute.js
+++ b/packages/react-static/src/static/exportRoute.js
@@ -98,12 +98,14 @@ export default (async function exportRoute(state) {
 
   // This routeInfo will be saved to disk. It should only include the
   // data and hashes to construct all of the props later.
-  const routeInfo = {
+  const routeInfo = await plugins.routeInfo({
     template,
     sharedHashesByProp,
     data,
     path: routePath,
-  }
+  }, state)
+
+
   // This embeddedRouteInfo will be inlined into the HTML for this route.
   // It should include all of the data, including shared data
   const embeddedRouteInfo = {

--- a/packages/react-static/src/static/plugins.js
+++ b/packages/react-static/src/static/plugins.js
@@ -1,39 +1,6 @@
 import { getHooks, reduceHooks } from '../utils'
 
-const supportedHooks = [
-  'afterGetConfig',
-  'beforePrepareBrowserPlugins',
-  'afterPrepareBrowserPlugins',
-  'beforePrepareRoutes',
-  'getRoutes',
-  'normalizeRoute',
-  'afterPrepareRoutes',
-  'webpack',
-  'afterBundle',
-  'afterDevServerStart',
-  'beforeRenderToElement',
-  'beforeRenderToHtml',
-  'htmlProps',
-  'headElements',
-  'beforeHtmlToDocument',
-  'beforeDocumentToFile',
-  'afterExport',
-  'plugins',
-]
-
-export const validatePlugin = plugin => {
-  const hookKeys = Object.keys(plugin.hooks)
-  const badKeys = hookKeys.filter(key => !supportedHooks.includes(key))
-  if (badKeys.length) {
-    throw new Error(
-      `Unknown plugin hooks: "${badKeys.join(', ')}" found in plugin: ${
-        plugin.location
-      }`
-    )
-  }
-}
-
-export default {
+const hooks = {
   afterGetConfig: state => {
     const hooks = getHooks(state.plugins, 'afterGetConfig')
     return reduceHooks(hooks, { sync: true })(state)
@@ -74,6 +41,10 @@ export default {
     const hooks = getHooks(state.plugins, 'afterDevServerStart')
     return reduceHooks(hooks)(state)
   },
+  routeInfo: (routeInfo, state) => {
+    const hooks = getHooks(state.plugins, 'routeInfo')
+    return reduceHooks(hooks)(routeInfo)
+  },
   beforeRenderToElement: (Comp, state) => {
     const hooks = getHooks(state.plugins, 'beforeRenderToElement')
     return reduceHooks(hooks)(Comp, state)
@@ -106,4 +77,19 @@ export default {
     const hooks = getHooks(state.plugins, 'plugins')
     return reduceHooks(hooks)(state)
   },
+}
+
+export default hooks
+
+export const validatePlugin = plugin => {
+  const validHookKeys = Object.keys(hooks);
+  const hookKeys = Object.keys(plugin.hooks)
+  const badKeys = hookKeys.filter(key => !validHookKeys.includes(key))
+  if (badKeys.length) {
+    throw new Error(
+        `Unknown plugin hooks: "${badKeys.join(', ')}" found in plugin: ${
+            plugin.location
+        }`
+    )
+  }
 }

--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -150,6 +150,7 @@ If this is a dynamic route, consider adding it to the prefetchExcludes list:
                 }
 
                 route = await getRouteData(route, latestState)
+                route = await plugins.routeInfo(route, state)
 
                 // Don't use any hashProp, just pass all the data in dev
                 res.json(route)


### PR DESCRIPTION
## Description

Allow plugins to modify routeInfo to for example add or modify the data that is used on a page.

## Changes/Tasks

- Call new routeInfo hook in exportRoute
- Call new routeInfo hook in dev server for each request
- Extract valid hooks from object, to remove extra list

## Motivation and Context

#1566

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
