### PR TITLE
Fix typo in react-static-plugin-sitemap readme

### DIFF
--- a/packages/react-static-plugin-sitemap/README.md
+++ b/packages/react-static-plugin-sitemap/README.md
@@ -55,8 +55,8 @@ export default {
     <lastmod>10/10/2010</lastmod>
     <priority>0.5</priority>
     <image:image>
-      <iamge:loc>https://raw.githubusercontent.com/react-static/react-static/master/media/react-static-logo-2x.png</iamge:loc>
-      <iamge:caption>React Static</iamge:caption>
+      <image:loc>https://raw.githubusercontent.com/react-static/react-static/master/media/react-static-logo-2x.png</iamge:loc>
+      <image:caption>React Static</iamge:caption>
     </image:image>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://hello.com/blog/post/1" />
     <xhtml:link rel="alternate" hreflang="en" href="https://hello.com/blog/post/1" />

--- a/packages/react-static-plugin-sitemap/README.md
+++ b/packages/react-static-plugin-sitemap/README.md
@@ -55,8 +55,8 @@ export default {
     <lastmod>10/10/2010</lastmod>
     <priority>0.5</priority>
     <image:image>
-      <image:loc>https://raw.githubusercontent.com/react-static/react-static/master/media/react-static-logo-2x.png</iamge:loc>
-      <image:caption>React Static</iamge:caption>
+      <image:loc>https://raw.githubusercontent.com/react-static/react-static/master/media/react-static-logo-2x.png</image:loc>
+      <image:caption>React Static</image:caption>
     </image:image>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://hello.com/blog/post/1" />
     <xhtml:link rel="alternate" hreflang="en" href="https://hello.com/blog/post/1" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a typo in the readme for the react-static-plugin-sitemap plugin

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Fixed typo

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The documentation should be accurate 

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
