### PR TITLE
Add React.Suspense wrapper to router guides.

### DIFF
--- a/docs/guides/dynamic-routes-reach-router.md
+++ b/docs/guides/dynamic-routes-reach-router.md
@@ -20,10 +20,12 @@ function App() {
         <Link to="/dynamic">Dynamic</Link>
       </nav>
       <div className="content">
-        <Router>
-          <Dynamic path="/dynamic/*" />
-          <Routes default />
-        </Router>
+        <React.Suspense fallback={<em>Loading...</em>}>
+          <Router>
+            <Dynamic path="/dynamic/*" />
+            <Routes default />
+          </Router>
+        </React.Suspense>
       </div>
     </Root>
   )

--- a/docs/guides/dynamic-routes-react-router.md
+++ b/docs/guides/dynamic-routes-react-router.md
@@ -25,10 +25,12 @@ function App() {
         <Link to="/dynamic">Dynamic</Link>
       </nav>
       <div className="content">
-        <Switch>
-          <Route path="/dynamic" component={Dynamic} />
-          <Route render={() => <Routes />} />
-        </Switch>
+        <React.Suspense fallback={<em>Loading...</em>}>
+          <Switch>
+            <Route path="/dynamic" component={Dynamic} />
+            <Route render={() => <Routes />} />
+          </Switch>
+        </React.Suspense>
       </div>
     </Root>
   )


### PR DESCRIPTION
Update the guides for routing to include <Suspense> component.

## Description

I was struggling with the same issue that I found in this discussion:

https://github.com/react-static/react-static/issues/1357

I had copied the code from the guides that did not have Suspense which it seems is required.

## Changes/Tasks

Only documentation is changed.

## Motivation and Context

It fixes documentation to match what is required for minimum working code.


## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
