### PR TITLE
Show a warning in development mode, when a template file does not have a default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Improved
 - Update emotion plugin to support 11 version ([#1558](https://github.com/react-static/react-static/pull/1558))
+- Show warning for missing template default export ([#1599](https://github.com/react-static/react-static/pull/1599))
 
 ### Bugfix
 Fix publicPath is used for webpack output publicPath instead of assetsPath ([#1569](https://github.com/react-static/react-static/pull/1569))

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -63,6 +63,9 @@ export const registerTemplates = async (tmps, notFoundKey) => {
   })
   Object.keys(tmps).forEach(key => {
     templates[key] = tmps[key]
+    if (!templates[key]) {
+      console.warn('Template registered without default export: ' + key.replace(/__react_static_root__\//, ''))
+    }
   })
   templatesByPath[PATH_404] = templates[notFoundKey]
 

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -64,7 +64,7 @@ export const registerTemplates = async (tmps, notFoundKey) => {
   Object.keys(tmps).forEach(key => {
     templates[key] = tmps[key]
     if (!templates[key]) {
-      console.warn('Template registered without default export: ' + key.replace(/__react_static_root__\//, ''))
+      console.warn(`Template registered without default export: ${key.replace(/__react_static_root__\//, '')}`)
     }
   })
   templatesByPath[PATH_404] = templates[notFoundKey]


### PR DESCRIPTION
At the moment, there is no indication why the 404 page is displayed instead of the actual page