### PR TITLE
Fix generation of staging sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Corrected mismatch between Sitemap documentation and implementation ([#1618](https://github.com/react-static/react-static/pull/1618))
 
 ### Bugfix
-Fix publicPath is used for webpack output publicPath instead of assetsPath ([#1569](https://github.com/react-static/react-static/pull/1569))
+- Fix publicPath is used for webpack output publicPath instead of assetsPath ([#1569](https://github.com/react-static/react-static/pull/1569))
+- Fix sitemap generation for staging context ([#1616](https://github.com/react-static/react-static/pull/1616))
 
 ## 7.5.3
 

--- a/packages/react-static-plugin-sitemap/src/__test__/__snapshots__/buildXML.test.js.snap
+++ b/packages/react-static-plugin-sitemap/src/__test__/__snapshots__/buildXML.test.js.snap
@@ -9,3 +9,13 @@ exports[`generateXML should support hreflang links  1`] = `"<?xml version=\\"1.0
 exports[`generateXML should use encoding for XML-values 1`] = `"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\"><url><loc>/this-&amp;-that/&quot;官话&quot;-is-chinese-&apos;ру́сский язы́к&apos;-is-russian/</loc></url></urlset>"`;
 
 exports[`generateXML should utilize custom sitemap properties 1`] = `"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\"><url><loc>/blog/path/to/somewhere/</loc><lastmod>10/10/2010</lastmod><priority>0.5</priority><image:image><image:loc>https://raw.githubusercontent.com/react-static/react-static/master/media/react-static-logo-2x.png</image:loc><image:caption>React Static</image:caption></image:image></url></urlset>"`;
+
+exports[`staging should return an xml string 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\">
+<url>
+<loc>/blog/path/to/somewhere/</loc>
+
+</url>
+</urlset>"
+`;

--- a/packages/react-static-plugin-sitemap/src/__test__/buildXML.test.js
+++ b/packages/react-static-plugin-sitemap/src/__test__/buildXML.test.js
@@ -1,4 +1,3 @@
-import fsExtra from 'fs-extra'
 import { getPermaLink, generateXML } from '../buildXML'
 
 describe('getPermaLink', () => {
@@ -163,6 +162,26 @@ describe('documentation example', () => {
       undefined,
       'https://hello.com/'
     )
+    expect(xml).toMatchSnapshot()
+  })
+})
+
+describe('staging', () => {
+  it('should return an xml string', () => {
+    const xml = generateXML(
+      {
+        routes: [
+          {
+            path: '/path/to/somewhere',
+          },
+        ],
+        staging: true,
+      },
+      undefined,
+      '/blog/'
+    )
+
+    expect(typeof xml).toEqual('string')
     expect(xml).toMatchSnapshot()
   })
 })

--- a/packages/react-static-plugin-sitemap/src/buildXML.js
+++ b/packages/react-static-plugin-sitemap/src/buildXML.js
@@ -108,9 +108,8 @@ function checkNestedValue(value) {
 
   if (typeof value === 'object' && value !== null) {
     return true
-  } else {
-    return false
   }
+  return false
 }
 
 function convertNestedValue(values, staging) {
@@ -155,15 +154,13 @@ function buildHrefLangLinks(hrefLangConfig, prefixPath) {
 
 function xmlArrayOutput(values, staging) {
   return [
-    ...values
-      .map(
-        ({ key, value }) =>
-          `<${key}>${
-            checkNestedValue(value)
-              ? convertNestedValue(value, staging)
-              : encode(value)
-          }</${key}>`
-      )
-      .join(staging ? '\n' : ''),
+    ...values.map(
+      ({ key, value }) =>
+        `<${key}>${
+          checkNestedValue(value)
+            ? convertNestedValue(value, staging)
+            : encode(value)
+        }</${key}>`
+    ),
   ].join(staging ? '\n' : '')
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sitemap generation in staging context had a bug that would add too many
linebreaks

<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code
- [x] Added test

## Motivation and Context

Fixes #1587

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them