### PR TITLE
Ensure `noindex` urls are excluded from sitemap.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugfix
 - Fix publicPath is used for webpack output publicPath instead of assetsPath ([#1569](https://github.com/react-static/react-static/pull/1569))
 - Fix sitemap generation for staging context ([#1616](https://github.com/react-static/react-static/pull/1616))
+- Ensure sitemap generation properly ignores `noindex` routes ([#1620](https://github.com/react-static/react-static/pull/1620))
 
 ## 7.5.3
 

--- a/packages/react-static-plugin-sitemap/README.md
+++ b/packages/react-static-plugin-sitemap/README.md
@@ -46,6 +46,12 @@ export default {
         },
       },
     },
+    {
+      path: '/blog/draft/2',
+      sitemap: {
+        noindex: true // Excludes route from sitemap.xml
+      },
+    },
   ]
   ```
 

--- a/packages/react-static-plugin-sitemap/src/__test__/buildXML.test.js
+++ b/packages/react-static-plugin-sitemap/src/__test__/buildXML.test.js
@@ -82,7 +82,8 @@ describe('generateXML', () => {
       {
         routes: [
           { path: '/path/to/article/' },
-          { path: '/path/to/somewhere/', noindex: true },
+          { path: '/path/to/hidden/', sitemap: { noindex: true } },
+          { path: '/path/to/somewhere/', sitemap: { noindex: false } },
           { path: '404' },
         ],
       },
@@ -90,7 +91,8 @@ describe('generateXML', () => {
       '/blog/'
     )
 
-    expect(xml.split('<loc>').length).toEqual(2)
+    expect(xml.split('<loc>').length).toEqual(3)
+    expect(xml).not.toContain('/path/to/hidden')
   })
 
   it('should support a custom getAttributes option ', () => {

--- a/packages/react-static-plugin-sitemap/src/buildXML.js
+++ b/packages/react-static-plugin-sitemap/src/buildXML.js
@@ -54,7 +54,7 @@ export function generateXML(
         return false
       }
       // Don't include routes with noindex: true
-      if (r.noindex) {
+      if (r.sitemap && r.sitemap.noindex) {
         return false
       }
       return true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Setting `noindex` to true for a route should exclude it from the
sitemap, but this is not happening. There is a interface mismatch
between the state and how `buildXML` handles the option

<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code
- [x] Changed test
- [x] Added documentation

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them